### PR TITLE
Fix openSUSE license path

### DIFF
--- a/usr/share/lib/img_proof/tests/openSUSE_Leap/test_leap_license.py
+++ b/usr/share/lib/img_proof/tests/openSUSE_Leap/test_leap_license.py
@@ -1,5 +1,5 @@
 def test_leap_license(host):
-    license_dir = '/etc/YaST2/licenses/base'
+    license_dir = '/usr/share/licenses/openSUSE-release'
     license_content = 'LICENSE AGREEMENT'
 
     lic_dir = host.file(license_dir)


### PR DESCRIPTION
The license files location is not correct for Leap 15.1 . See
https://build.opensuse.org/package/binary/download/openSUSE:Leap:15.1/000release-packages:openSUSE-release/standard/x86_64/openSUSE-release-15.1-lp151.298.1.x86_64.rpm

Resolves #204 