### PR TITLE
Make license test fixture generic.

### DIFF
--- a/usr/share/lib/img_proof/tests/SLES/SAP/test_sles_sap_license.py
+++ b/usr/share/lib/img_proof/tests/SLES/SAP/test_sles_sap_license.py
@@ -1,9 +1,7 @@
 import pytest
 
 
-def test_sles_sap_license(
-    host, confirm_sles_license_content, get_release_value
-):
+def test_sles_sap_license(confirm_license_content, get_release_value):
     version = get_release_value('VERSION')
 
     if version == '12-SP4':
@@ -15,7 +13,12 @@ def test_sles_sap_license(
         '/etc/YaST2/licenses/SLES_SAP/',
         '/usr/share/licenses/product/SLES_SAP/'
     ]
-    result = confirm_sles_license_content(license_dirs)
+    license_content = [
+        'SUSE End User License Agreement',
+        'SUSE(R) Linux Enterprise End User License Agreement',
+        'SUSE® Linux Enterprise End User License Agreement'
+    ]
+    result = confirm_license_content(license_dirs, license_content)
 
     if result is False:
         pytest.fail(

--- a/usr/share/lib/img_proof/tests/SLES/conftest.py
+++ b/usr/share/lib/img_proof/tests/SLES/conftest.py
@@ -353,27 +353,3 @@ def is_sles_sap(host):
         sap = host.file('/etc/products.d/SLES_SAP.prod')
         return sap.exists and sap.is_file
     return f
-
-
-@pytest.fixture()
-def confirm_sles_license_content(host):
-    def f(license_dirs):
-        license_content = [
-            'SUSE End User License Agreement',
-            'SUSE(R) Linux Enterprise End User License Agreement',
-            'SUSE® Linux Enterprise End User License Agreement'
-        ]
-
-        for license_dir in license_dirs:
-            lic_dir = host.file(license_dir)
-
-            if lic_dir.exists and lic_dir.is_directory:
-                lic = host.file(license_dir + 'license.txt')
-                return all([
-                    lic.exists,
-                    lic.is_file,
-                    any(lic.contains(content) for content in license_content)
-                ])
-
-        return False
-    return f

--- a/usr/share/lib/img_proof/tests/SLES/test_sles_license.py
+++ b/usr/share/lib/img_proof/tests/SLES/test_sles_license.py
@@ -1,14 +1,19 @@
 import pytest
 
 
-def test_sles_license(host, confirm_sles_license_content):
+def test_sles_license(confirm_license_content):
     license_dirs = [
         '/etc/YaST2/licenses/base/',
         '/etc/YaST2/licenses/SLES/',
         '/usr/share/licenses/product/base/',
         '/usr/share/licenses/product/SLES/'
     ]
-    result = confirm_sles_license_content(license_dirs)
+    license_content = [
+        'SUSE End User License Agreement',
+        'SUSE(R) Linux Enterprise End User License Agreement',
+        'SUSE® Linux Enterprise End User License Agreement'
+    ]
+    result = confirm_license_content(license_dirs, license_content)
 
     if result is False:
         pytest.fail(

--- a/usr/share/lib/img_proof/tests/conftest.py
+++ b/usr/share/lib/img_proof/tests/conftest.py
@@ -229,3 +229,21 @@ def install_zypper_package(host):
         result = host.run('sudo zypper -n in %s' % name)
         return result.rc
     return f
+
+
+@pytest.fixture()
+def confirm_license_content(host):
+    def f(license_dirs, license_content):
+        for license_dir in license_dirs:
+            lic_dir = host.file(license_dir)
+
+            if lic_dir.exists and lic_dir.is_directory:
+                lic = host.file(license_dir + 'license.txt')
+                return all([
+                    lic.exists,
+                    lic.is_file,
+                    any(lic.contains(content) for content in license_content)
+                ])
+
+        return False
+    return f

--- a/usr/share/lib/img_proof/tests/openSUSE_Leap/test_leap_license.py
+++ b/usr/share/lib/img_proof/tests/openSUSE_Leap/test_leap_license.py
@@ -1,12 +1,18 @@
-def test_leap_license(host):
-    license_dir = '/etc/YaST2/licenses/base'
-    license_content = 'LICENSE AGREEMENT'
+import pytest
 
-    lic_dir = host.file(license_dir)
-    assert lic_dir.exists
-    assert lic_dir.is_directory
 
-    license = host.file(license_dir + '/license.txt')
-    assert license.exists
-    assert license.is_file
-    assert license.contains(license_content)
+def test_leap_license(confirm_license_content):
+    license_dirs = [
+        '/etc/YaST2/licenses/base/',
+        '/usr/share/licenses/openSUSE-release/'
+    ]
+    license_content = [
+        'LICENSE AGREEMENT'
+    ]
+    result = confirm_license_content(license_dirs, license_content)
+
+    if result is False:
+        pytest.fail(
+            'SUSE End User License Agreement not found '
+            'or license has incorrect content.'
+        )


### PR DESCRIPTION
Update sles and sles sap license test to pass list of possible license content. Update Leap license test to use fixture and add new license directory.

Fixes #204 and related to #205 