### PR TITLE
- Use the "baseproduct" link as indicator of the product, SLES vs. SL…

### DIFF
--- a/usr/share/lib/img_proof/tests/SLES/conftest.py
+++ b/usr/share/lib/img_proof/tests/SLES/conftest.py
@@ -345,11 +345,3 @@ def get_sles_repos():
     def f(version):
         return SLES_REPOS.get(version)
     return f
-
-
-@pytest.fixture()
-def is_sles_sap(host):
-    def f():
-        sap = host.file('/etc/products.d/SLES_SAP.prod')
-        return sap.exists and sap.is_file
-    return f

--- a/usr/share/lib/img_proof/tests/conftest.py
+++ b/usr/share/lib/img_proof/tests/conftest.py
@@ -165,7 +165,7 @@ def determine_region(host):
 
 
 @pytest.fixture()
-def get_sles_baseproduct(host):
+def get_baseproduct(host):
     """
     Return the name of the file the 'baseproduct' link points to.
     """
@@ -176,11 +176,11 @@ def get_sles_baseproduct(host):
 
 
 @pytest.fixture()
-def is_sles_sap(host, get_sles_baseproduct):
+def is_sles_sap(host, get_baseproduct):
     def f():
         sap_product = '/etc/products.d/SLES_SAP.prod'
         sap = host.file(sap_product)
-        base_product = get_sles_baseproduct()
+        base_product = get_baseproduct()
 
         return all([
             sap.exists,

--- a/usr/share/lib/img_proof/tests/conftest.py
+++ b/usr/share/lib/img_proof/tests/conftest.py
@@ -1,4 +1,5 @@
 import json
+import os
 import pytest
 
 from susepubliccloudinfoclient import infoserverrequests
@@ -164,6 +165,14 @@ def determine_region(host):
 
 
 @pytest.fixture()
+def get_baseproduct():
+    """Return the nmae of the file the 'baseproduct' link points to"""
+    baseproduct = '/etc/products.d/baseproduct'
+    if os.path.islink(baseproduct):
+        return os.readlink(baseproduct).split('.')[0]
+
+
+@pytest.fixture()
 def get_release_value(host):
     def f(key):
         release = host.file('/etc/os-release')
@@ -194,8 +203,8 @@ def get_smt_server_name(host):
 @pytest.fixture()
 def get_smt_servers(get_release_value, host):
     def f(provider, region):
-        cpe_name = get_release_value('CPE_NAME')
-        if 'sap' in cpe_name:
+        product_name = get_baseproduct()
+        if 'sap' in product_name.lower():
             smt_type = 'smt-sap'
         else:
             smt_type = 'smt-sles'


### PR DESCRIPTION
…ES4SAP

  + If the baseproduct link is not correct then registration would also not
    be correct. Thus the link is a more reliable indicator as compared to the
    information in os-release