### PR TITLE
Make tox env work with python3.7

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,12 @@ envlist =
     py34
     py35
     py36
+    py37
 
 [testenv]
 passenv = HOME
 commands =
     pip install -e .[dev]
-    pytest --cov=img-proof
+    pytest --cov=img_proof
     flake8 img-proof
     flake8 tests --exclude=data


### PR DESCRIPTION
Added py37 to tox.ini to make tox environment work on Tumbleweed.
Also fixed a typo that broke testing.