### PR TITLE
Indicate retryable error (GCE only)

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,7 +26,7 @@ author = 'SUSE'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '4.1.1'
+release = '4.2.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/img_proof/__init__.py
+++ b/img_proof/__init__.py
@@ -22,4 +22,4 @@
 
 __author__ = """SUSE"""
 __email__ = 'public-cloud-dev@susecloud.net'
-__version__ = '4.1.1'
+__version__ = '4.2.0'

--- a/img_proof/ipa_cloud.py
+++ b/img_proof/ipa_cloud.py
@@ -44,7 +44,9 @@ from img_proof.ipa_sles import SLES
 from img_proof.ipa_exceptions import (
     IpaException,
     IpaCloudException,
-    IpaSSHException
+    IpaSSHException,
+    IpaRetryableError,
+    GCECloudRetryableError
 )
 from img_proof.results_plugin import Report
 
@@ -641,7 +643,12 @@ class IpaCloud(object):
         else:
             # Launch new instance
             self.logger.info('Launching new instance')
-            self._launch_instance()
+            try:
+                self._launch_instance()
+            except GCECloudRetryableError as error:
+                raise IpaRetryableError(
+                    'Unable to connect to instance: %s' % error
+                )
 
         if not self.instance_ip:
             self._set_instance_ip()

--- a/img_proof/ipa_exceptions.py
+++ b/img_proof/ipa_exceptions.py
@@ -40,8 +40,10 @@ class EC2CloudException(IpaCloudException):
 class GCECloudException(IpaCloudException):
     """Generic GCE exception."""
 
+
 class GCECloudRetryableError(GCECloudException):
     """GCE retryable error exception."""
+
 
 class IpaControllerException(IpaException):
     """Generic exception for img_proof controller module."""
@@ -78,8 +80,10 @@ class IpaUtilsException(IpaException):
 class IpaSSHException(IpaUtilsException):
     """Generic exception for img_proof SSH methods."""
 
+
 class IpaRetryableError(IpaCloudException):
     """Generic retryable error exception."""
+
 
 class SSHCloudException(IpaUtilsException):
     """Generic exception for SSH class."""

--- a/img_proof/ipa_exceptions.py
+++ b/img_proof/ipa_exceptions.py
@@ -40,6 +40,8 @@ class EC2CloudException(IpaCloudException):
 class GCECloudException(IpaCloudException):
     """Generic GCE exception."""
 
+class GCECloudRetryableError(GCECloudException):
+    """GCE retryable error exception."""
 
 class IpaControllerException(IpaException):
     """Generic exception for img_proof controller module."""
@@ -76,6 +78,8 @@ class IpaUtilsException(IpaException):
 class IpaSSHException(IpaUtilsException):
     """Generic exception for img_proof SSH methods."""
 
+class IpaRetryableError(IpaCloudException):
+    """Generic retryable error exception."""
 
 class SSHCloudException(IpaUtilsException):
     """Generic exception for SSH class."""

--- a/img_proof/ipa_gce.py
+++ b/img_proof/ipa_gce.py
@@ -236,7 +236,7 @@ class GCECloud(IpaCloud):
         except QuotaExceededError as error:
             raise GCECloudRetryableError(
                 'An error occurred launching instance: {message}.'.format(
-                    message=message
+                    message=error.value['message']
                 )
             )
         except GoogleBaseError as error:

--- a/img_proof/ipa_gce.py
+++ b/img_proof/ipa_gce.py
@@ -29,9 +29,12 @@ from img_proof.ipa_constants import (
     GCE_DEFAULT_USER
 )
 from img_proof.ipa_exceptions import GCECloudException
+from img_proof.ipa_exceptions import GCECloudRetryableError
 from img_proof.ipa_cloud import IpaCloud
 
 from libcloud.common.google import ResourceNotFoundError
+from libcloud.common.google import GoogleBaseError
+from libcloud.common.google import QuotaExceededError
 from libcloud.compute.types import Provider
 from libcloud.compute.providers import get_driver
 
@@ -230,6 +233,25 @@ class GCECloud(IpaCloud):
                     message=message
                 )
             )
+        except QuotaExceededError as error:
+            raise GCECloudRetryableError(
+                'An error occurred launching instance: {message}.'.format(
+                    message=message
+                )
+            )
+        except GoogleBaseError as error:
+            if error.value['reason'] == 'quotaExceeded':
+                raise GCECloudRetryableError(
+                    'An error occurred launching instance: {message}.'.format(
+                        message=error.value['message']
+                    )
+                )
+            else:
+                raise GCECloudException(
+                    'An error occurred launching instance: {message}.'.format(
+                        message=error.value['message']
+                    )
+                )
 
         self.compute_driver.wait_until_running(
             [instance],

--- a/package/python3-img-proof.spec
+++ b/package/python3-img-proof.spec
@@ -18,7 +18,7 @@
 
 %bcond_without test
 Name:           python3-img-proof
-Version:        4.1.1
+Version:        4.2.0
 Release:        0
 Summary:        Command line and API for testing custom images
 License:        GPL-3.0-or-later
@@ -60,7 +60,7 @@ BuildRequires:  python3-pytest
 BuildRequires:  python3-pytest-cov
 BuildRequires:  python3-testinfra
 %endif
-Obsoletes:      python3-ipa < 4.1.1
+Obsoletes:      python3-ipa < 4.2.0
 
 %description
 img-proof provides a command line utility to test images in
@@ -71,7 +71,7 @@ Summary:        Infrastructure tests for img-proof
 Group:          Development/Languages/Python
 Requires:       python3-susepubliccloudinfo
 PreReq:         python3-img-proof = %{version}
-Obsoletes:      python3-ipa-tests < 4.1.1
+Obsoletes:      python3-ipa-tests < 4.2.0
 
 %description tests
 Directory of infrastructure tests for testing images.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 4.1.1
+current_version = 4.2.0
 commit = True
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ tox_requirements = [
 
 setup(
     name='img-proof',
-    version='4.1.1',
+    version='4.2.0',
     description="Package for automated testing of cloud images.",
     long_description=readme,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
If instance cannot be launched in GCE due to quota restriction, throw IpaRetryableError exception.