### PR TITLE
Wait longer on soft reboot

### DIFF
--- a/img_proof/ipa_distro.py
+++ b/img_proof/ipa_distro.py
@@ -143,7 +143,7 @@ class Distro(object):
             transport = client.get_transport()
             channel = transport.open_session()
             channel.exec_command(reboot_cmd)
-            time.sleep(1)  # Required for delay in reboot
+            time.sleep(2)  # Required for delay in reboot
             transport.close()
         except Exception as error:
             raise IpaDistroException(

--- a/tests/test_ipa_azure.py
+++ b/tests/test_ipa_azure.py
@@ -142,8 +142,27 @@ class TestAzureProvider(object):
 
     @patch.object(AzureCloud, '_wait_on_instance')
     @patch('img_proof.ipa_utils.generate_instance_name')
-    def test_azure_launch_instance(
+    def test_azure_launch_instance_exception(
         self, mock_generate_instance_name, mock_wait_on_instance
+    ):
+        """Test launch instance method."""
+        mock_generate_instance_name.return_value = 'azure-test-instance'
+        self.client.resource_groups.create_or_update.side_effect = Exception(
+            'Cannot create resource group!'
+        )
+        self.client.resource_groups.delete.side_effect = Exception(
+            'Cannot delete resource group!'
+        )
+
+        provider = self.helper_get_provider()
+
+        with pytest.raises(AzureCloudException):
+            provider._launch_instance()
+
+    @patch.object(AzureCloud, '_wait_on_instance')
+    @patch('img_proof.ipa_utils.generate_instance_name')
+    def test_azure_launch_instance(
+            self, mock_generate_instance_name, mock_wait_on_instance
     ):
         """Test launch instance method."""
         mock_generate_instance_name.return_value = 'azure-test-instance'


### PR DESCRIPTION
Wait 1 second longer for SSH service to go down before continuing. Otherwise there's a chance for an ssh connection to be established prior to reboot.

Add test for azure launch exception (test coverage dropped below minimums).