### PR TITLE
Print serial console output to log.

### DIFF
--- a/img_proof/ipa_azure.py
+++ b/img_proof/ipa_azure.py
@@ -580,3 +580,11 @@ class AzureCloud(IpaCloud):
             raise AzureCloudException(
                 'Unable to terminate resource group: {0}.'.format(error)
             )
+
+    def get_console_log(self):
+        """
+        Return console log output if it is available.
+
+        Currently there is no way to get console log from API.
+        """
+        return ''

--- a/img_proof/ipa_ec2.py
+++ b/img_proof/ipa_ec2.py
@@ -22,6 +22,7 @@
 
 import boto3
 import os
+import time
 
 from collections import ChainMap, defaultdict
 
@@ -314,3 +315,25 @@ class EC2Cloud(IpaCloud):
         """Terminate the instance."""
         instance = self._get_instance()
         instance.terminate()
+
+    def get_console_log(self):
+        """
+        Return console log output if it is available.
+
+        Boto3 will return a response with no output if serial console
+        is not available.
+        """
+        instance = self._get_instance()
+
+        start = time.time()
+        end = start + 300
+
+        while time.time() < end:
+            response = instance.console_output()
+
+            if 'Output' in response:
+                return response['Output']
+
+            time.sleep(10)
+
+        return ''

--- a/img_proof/ipa_gce.py
+++ b/img_proof/ipa_gce.py
@@ -326,3 +326,11 @@ class GCECloud(IpaCloud):
         """Terminate the instance."""
         instance = self._get_instance()
         instance.destroy()
+
+    def get_console_log(self):
+        """
+        Return console log output if it is available.
+        """
+        instance = self._get_instance()
+        output = self.compute_driver.ex_get_serial_output(instance)
+        return output

--- a/tests/test_ipa_cloud.py
+++ b/tests/test_ipa_cloud.py
@@ -44,7 +44,8 @@ NOT_IMPL_METHODS = [
     '_set_instance_ip',
     '_start_instance',
     '_stop_instance',
-    '_terminate_instance'
+    '_terminate_instance',
+    'get_console_log'
 ]
 
 
@@ -384,6 +385,7 @@ class TestIpaCloud(object):
             client, 'python test.py'
         )
 
+    @patch.object(IpaCloud, 'get_console_log')
     @patch.object(IpaCloud, '_set_instance_ip')
     @patch.object(IpaCloud, '_set_image_id')
     @patch.object(IpaCloud, '_start_instance_if_stopped')
@@ -393,13 +395,15 @@ class TestIpaCloud(object):
         mock_get_ssh_client,
         mock_start_instance,
         mock_set_image_id,
-        mock_set_instance_ip
+        mock_set_instance_ip,
+        mock_get_console_log
     ):
         """Test exception raised when connection cannot be established."""
         mock_get_ssh_client.side_effect = IpaSSHException('ERROR!')
         mock_start_instance.return_value = None
         mock_set_image_id.return_value = None
         mock_set_instance_ip.return_value = None
+        mock_get_console_log.return_value = 'Console log output...'
         self.kwargs['running_instance_id'] = 'fakeinstance'
 
         cloud = IpaCloud(*args, **self.kwargs)

--- a/tests/test_ipa_ec2.py
+++ b/tests/test_ipa_ec2.py
@@ -272,3 +272,18 @@ class TestEC2Provider(object):
         provider = EC2Cloud(**self.kwargs)
         provider._terminate_instance()
         assert mock_get_instance.call_count == 1
+
+    @patch('time.sleep')
+    @patch.object(EC2Cloud, '_get_instance')
+    def test_ec2_get_console_log(self, mock_get_instance, mock_time):
+        """Test ec2 get console log method."""
+        instance = MagicMock()
+        instance.console_output.return_value = {
+            'Output': 'Console log output...'
+        }
+        mock_get_instance.return_value = instance
+
+        provider = EC2Cloud(**self.kwargs)
+        output = provider.get_console_log()
+        assert output == 'Console log output...'
+        assert mock_get_instance.call_count == 1

--- a/tests/test_ipa_gce.py
+++ b/tests/test_ipa_gce.py
@@ -300,3 +300,14 @@ class TestGCECloud(object):
 
         self.cloud._terminate_instance()
         assert instance.destroy.call_count == 1
+
+    @patch.object(GCECloud, '_get_instance')
+    def test_gce_get_console_log(self, mock_get_instance):
+        """Test gce get console log method."""
+        instance = MagicMock()
+        mock_get_instance.return_value = instance
+        self.cloud.compute_driver.ex_get_serial_output.return_value = 'output'
+
+        output = self.cloud.get_console_log()
+        assert output == 'output'
+        assert self.cloud.compute_driver.ex_get_serial_output.call_count == 1


### PR DESCRIPTION
If an instance is unreachable after boot save serial console to log if it is available.

This feature is available for ec2 and gce.

Fixes #216 