### PR TITLE
Add case for checking kernel config version

### DIFF
--- a/usr/share/lib/img_proof/tests/SLES/test_sles.yaml
+++ b/usr/share/lib/img_proof/tests/SLES/test_sles.yaml
@@ -7,3 +7,4 @@ tests:
   - test_sles_hostname
   - test_sles_haveged
   - test_sles_lscpu
+  - test_sles_kernel_version

--- a/usr/share/lib/img_proof/tests/SLES/test_sles_kernel_version.py
+++ b/usr/share/lib/img_proof/tests/SLES/test_sles_kernel_version.py
@@ -1,0 +1,9 @@
+def test_sles_kernel_version(host, get_release_value):
+    version = get_release_value('VERSION')
+    assert version
+    version = version.split('-SP')
+    config = host.run('sudo zcat /proc/config.gz')
+    assert 'CONFIG_SUSE_VERSION={}\n'.format(version[0]) in config.stdout
+    if len(version) > 1:
+        assert 'CONFIG_SUSE_PATCHLEVEL={}\n'.format(
+                version[1]) in config.stdout


### PR DESCRIPTION
This test checks if kernel config contains correct version number
by comparing version read from /etc/os-relase against
CONFIG_SUSE_VERSION and CONFIG_SUSE_PATHLEVEL.