### PR TITLE
Remove region filter from smt registration test.

### DIFF
--- a/usr/share/lib/img_proof/tests/SLES/test_sles_smt_reg.py
+++ b/usr/share/lib/img_proof/tests/SLES/test_sles_smt_reg.py
@@ -3,16 +3,14 @@ import shlex
 
 def test_sles_smt_reg(check_cloud_register,
                       determine_provider,
-                      determine_region,
                       get_smt_server_name,
                       get_smt_servers,
                       host):
     provider = determine_provider()
-    region = determine_region(provider)
 
     assert check_cloud_register()
 
-    servers = get_smt_servers(provider, region)
+    servers = get_smt_servers(provider)
     smt_ips = [server['ip'] for server in servers]
 
     result = host.run(

--- a/usr/share/lib/img_proof/tests/conftest.py
+++ b/usr/share/lib/img_proof/tests/conftest.py
@@ -160,8 +160,8 @@ def get_smt_server_name(host):
 
 
 @pytest.fixture()
-def get_smt_servers(get_release_value, host):
-    def f(provider, region):
+def get_smt_servers():
+    def f(provider, region=None):
         if provider == 'azure':
             provider = 'microsoft'
         elif provider == 'ec2':
@@ -171,13 +171,13 @@ def get_smt_servers(get_release_value, host):
         else:
             raise Exception('Provider %s unknown' % provider)
 
+        args = [provider, 'smt', 'json']
+
+        if region:
+            args.append(region)
+
         output = json.loads(
-            infoserverrequests.get_server_data(
-                provider,
-                'smt',
-                'json',
-                region
-            )
+            infoserverrequests.get_server_data(*args)
         )
 
         return output['servers']


### PR DESCRIPTION
- Not all regions have smt servers, some regions redirect to other regions. For registration test only check that the IP maps to a correct server.
- Cleanup unused fixture imports.
- Make region optional.