### PR TITLE
Run remote python command for checking system registered with sudo

### DIFF
--- a/usr/share/lib/img_proof/tests/conftest.py
+++ b/usr/share/lib/img_proof/tests/conftest.py
@@ -8,7 +8,7 @@ from susepubliccloudinfoclient import infoserverrequests
 def check_cloud_register(host):
     def f():
         result = host.run(
-            "python3 -c 'from cloudregister import registerutils; "
+            "sudo python3 -c 'from cloudregister import registerutils; "
             "print(registerutils.is_registered(registerutils.get_current_smt()))'"
         )
         output = result.stdout.strip()


### PR DESCRIPTION
In EC2, while running that command it gives an error:

```
python3 -c 'from cloudregister import registerutils;
> print(registerutils.is_registered(registerutils.get_current_smt()))'
Traceback (most recent call last):
  File "<string>", line 2, in <module>
  File "/usr/lib/python3.4/site-packages/cloudregister/registerutils.py", line 442, in get_current_smt
    smt = get_smt_from_store(__get_registered_smt_file_path())
  File "/usr/lib/python3.4/site-packages/cloudregister/registerutils.py", line 588, in get_smt_from_store
    with open(smt_store_file_path, 'rb') as smt_file:
PermissionError: [Errno 13] Permission denied: '/var/lib/cloudregister/currentSMTInfo.obj'
```

Running the same command with sudo grants access to that file and the tests passes.