### PR TITLE
Skip kernel test if not a latest image version.

### DIFF
--- a/usr/share/lib/img_proof/tests/SLES/test_sles_kernel_version.py
+++ b/usr/share/lib/img_proof/tests/SLES/test_sles_kernel_version.py
@@ -1,9 +1,14 @@
 def test_sles_kernel_version(host, get_release_value):
     version = get_release_value('VERSION')
     assert version
-    version = version.split('-SP')
-    config = host.run('sudo zcat /proc/config.gz')
-    assert 'CONFIG_SUSE_VERSION={}\n'.format(version[0]) in config.stdout
-    if len(version) > 1:
-        assert 'CONFIG_SUSE_PATCHLEVEL={}\n'.format(
-                version[1]) in config.stdout
+
+    if version not in ('11.4', '12-SP1', '12-SP2', '12-SP3'):
+        version = version.split('-SP')
+        config = host.run('sudo zcat /proc/config.gz')
+
+        assert 'CONFIG_SUSE_VERSION={}\n'.format(version[0]) in config.stdout
+
+        if len(version) > 1:
+            assert 'CONFIG_SUSE_PATCHLEVEL={}\n'.format(
+                version[1]
+            ) in config.stdout

--- a/usr/share/lib/img_proof/tests/SLES/test_sles_kernel_version.py
+++ b/usr/share/lib/img_proof/tests/SLES/test_sles_kernel_version.py
@@ -1,14 +1,19 @@
+import pytest
+
+
 def test_sles_kernel_version(host, get_release_value):
     version = get_release_value('VERSION')
     assert version
 
-    if version not in ('11.4', '12-SP1', '12-SP2', '12-SP3'):
-        version = version.split('-SP')
-        config = host.run('sudo zcat /proc/config.gz')
+    if version in ('11.4', '12-SP1', '12-SP2', '12-SP3'):
+        pytest.skip('Whoops! Image does not have version in kernel config.')
 
-        assert 'CONFIG_SUSE_VERSION={}\n'.format(version[0]) in config.stdout
+    version = version.split('-SP')
+    config = host.run('sudo zcat /proc/config.gz')
 
-        if len(version) > 1:
-            assert 'CONFIG_SUSE_PATCHLEVEL={}\n'.format(
-                version[1]
-            ) in config.stdout
+    assert 'CONFIG_SUSE_VERSION={}\n'.format(version[0]) in config.stdout
+
+    if len(version) > 1:
+        assert 'CONFIG_SUSE_PATCHLEVEL={}\n'.format(
+            version[1]
+        ) in config.stdout


### PR DESCRIPTION
Older images do not have the CONFIG_SUSE_VERSION or CONFIG_SUSE_PATCHLEVEL available.