### PR TITLE
Add distro refresh option.

### DIFF
--- a/img_proof/ipa_cloud.py
+++ b/img_proof/ipa_cloud.py
@@ -803,7 +803,7 @@ class IpaCloud(object):
                     result = 1
 
                     try:
-                        out = self.distro.refresh(self._get_ssh_client())
+                        out = self.distro.repo_refresh(self._get_ssh_client())
                         result = 0
                     except Exception as error:
                         self.logger.error('Instance failed to refresh')

--- a/img_proof/ipa_cloud.py
+++ b/img_proof/ipa_cloud.py
@@ -797,6 +797,26 @@ class IpaCloud(object):
                         )
                         status = status or result
 
+                elif item == 'test_refresh':
+                    self.logger.info('Testing refresh')
+                    start = time.time()
+                    result = 1
+
+                    try:
+                        out = self.distro.refresh(self._get_ssh_client())
+                        result = 0
+                    except Exception as error:
+                        self.logger.error('Instance failed to refresh')
+                        self.logger.debug(error)
+                    else:
+                        self._write_to_log(out)
+                    finally:
+                        duration = time.time() - start
+                        self._process_test_results(
+                            duration, 'test_refresh', result
+                        )
+                        status = status or result
+
                 elif isinstance(item, set):
                     self.logger.info('Running tests %s' % ' '.join(item))
                     with open(self.log_file, 'a') as log_file:

--- a/img_proof/ipa_constants.py
+++ b/img_proof/ipa_constants.py
@@ -50,7 +50,8 @@ echo {key} >> /home/{user}/.ssh/authorized_keys
 SYNC_POINTS = (
     'test_hard_reboot',
     'test_soft_reboot',
-    'test_update'
+    'test_update',
+    'test_refresh'
 )
 
 TEST_PATHS = (

--- a/img_proof/ipa_distro.py
+++ b/img_proof/ipa_distro.py
@@ -171,7 +171,7 @@ class Distro(object):
             )
         return out
 
-    def refresh(self, client):
+    def repo_refresh(self, client):
         """Execute repo refresh command on instance."""
         update_cmd = "{sudo} '{refresh}'".format(
             sudo=self.get_sudo_exec_wrapper(),

--- a/img_proof/ipa_distro.py
+++ b/img_proof/ipa_distro.py
@@ -170,3 +170,22 @@ class Distro(object):
                 'An error occurred updating instance: %s' % error
             )
         return out
+
+    def refresh(self, client):
+        """Execute repo refresh command on instance."""
+        update_cmd = "{sudo} '{refresh}'".format(
+            sudo=self.get_sudo_exec_wrapper(),
+            refresh=self.get_refresh_repo_cmd()
+        )
+
+        out = ''
+        try:
+            out = ipa_utils.execute_ssh_command(
+                client,
+                update_cmd
+            )
+        except Exception as error:
+            raise IpaDistroException(
+                'An error occurred refreshing repos on instance: %s' % error
+            )
+        return out

--- a/tests/test_ipa_cloud.py
+++ b/tests/test_ipa_cloud.py
@@ -564,6 +564,44 @@ class TestIpaCloud(object):
     @patch.object(IpaCloud, '_set_image_id')
     @patch.object(IpaCloud, '_start_instance_if_stopped')
     @patch.object(IpaCloud, '_get_ssh_client')
+    @patch.object(IpaCloud, '_terminate_instance')
+    @patch('img_proof.ipa_utils.get_host_key_fingerprint')
+    @patch.object(Distro, 'refresh')
+    def test_cloud_distro_refresh(
+            self,
+            mock_distro_refresh,
+            mock_get_host_key,
+            mock_terminate_instance,
+            mock_get_ssh_client,
+            mock_start_instance,
+            mock_set_image_id,
+            mock_set_instance_ip
+    ):
+        """Test exception raised when invalid test item provided."""
+        mock_distro_refresh.return_value = 'Refreshed!'
+        mock_get_host_key.return_value = b'04820482'
+        mock_terminate_instance.return_value = None
+        mock_get_ssh_client.return_value = None
+        mock_start_instance.return_value = None
+        mock_set_image_id.return_value = None
+        mock_set_instance_ip.return_value = None
+        self.kwargs['running_instance_id'] = 'fakeinstance'
+        self.kwargs['test_files'] = ['test_refresh']
+        self.kwargs['cleanup'] = True
+
+        cloud = IpaCloud(*args, **self.kwargs)
+        cloud.ssh_private_key_file = 'tests/data/ida_test'
+        cloud.ssh_user = 'root'
+
+        status, results = cloud.test_image()
+        assert status == 0
+        assert mock_distro_refresh.call_count == 1
+        self.kwargs['cleanup'] = None
+
+    @patch.object(IpaCloud, '_set_instance_ip')
+    @patch.object(IpaCloud, '_set_image_id')
+    @patch.object(IpaCloud, '_start_instance_if_stopped')
+    @patch.object(IpaCloud, '_get_ssh_client')
     @patch('img_proof.ipa_utils.get_host_key_fingerprint')
     @patch.object(IpaCloud, '_run_tests')
     def test_cloud_break_if_test_failure(

--- a/tests/test_ipa_cloud.py
+++ b/tests/test_ipa_cloud.py
@@ -566,7 +566,7 @@ class TestIpaCloud(object):
     @patch.object(IpaCloud, '_get_ssh_client')
     @patch.object(IpaCloud, '_terminate_instance')
     @patch('img_proof.ipa_utils.get_host_key_fingerprint')
-    @patch.object(Distro, 'refresh')
+    @patch.object(Distro, 'repo_refresh')
     def test_cloud_distro_refresh(
             self,
             mock_distro_refresh,

--- a/tests/test_ipa_sles_distro.py
+++ b/tests/test_ipa_sles_distro.py
@@ -135,7 +135,7 @@ def test_sles_refresh():
 
     with patch('img_proof.ipa_utils.execute_ssh_command',
                MagicMock(return_value='Refresh finished!')) as mocked:
-        output = sles.refresh(client)
+        output = sles.repo_refresh(client)
 
     mocked.assert_called_once_with(
         client,
@@ -153,7 +153,7 @@ def test_sles_refresh_exception():
             side_effect=Exception('ERROR!'))) as mocked:
         pytest.raises(
             IpaDistroException,
-            sles.refresh,
+            sles.repo_refresh,
             client
         )
 

--- a/tests/test_ipa_sles_distro.py
+++ b/tests/test_ipa_sles_distro.py
@@ -126,3 +126,38 @@ def test_sles_update_exception():
         "sudo sh -c 'zypper -n refresh;zypper -n up "
         "--auto-agree-with-licenses --force-resolution --replacefiles'"
     )
+
+
+def test_sles_refresh():
+    """Test refresh method for SLES distro."""
+    client = MagicMock()
+    sles = SLES()
+
+    with patch('img_proof.ipa_utils.execute_ssh_command',
+               MagicMock(return_value='Refresh finished!')) as mocked:
+        output = sles.refresh(client)
+
+    mocked.assert_called_once_with(
+        client,
+        "sudo sh -c 'zypper -n refresh'"
+    )
+    assert output == 'Refresh finished!'
+
+
+def test_sles_refresh_exception():
+    """Test refresh method exception for SLES distro."""
+    client = MagicMock()
+    sles = SLES()
+
+    with patch('img_proof.ipa_utils.execute_ssh_command', MagicMock(
+            side_effect=Exception('ERROR!'))) as mocked:
+        pytest.raises(
+            IpaDistroException,
+            sles.refresh,
+            client
+        )
+
+    mocked.assert_called_once_with(
+        client,
+        "sudo sh -c 'zypper -n refresh'"
+    )

--- a/usr/share/lib/img_proof/tests/SLES/test_sles_on_demand.yaml
+++ b/usr/share/lib/img_proof/tests/SLES/test_sles_on_demand.yaml
@@ -1,6 +1,6 @@
 tests:
   - test_sles_wait_on_registration
-  - test_update
+  - test_refresh
   - test_sles_repos
   - test_sles_smt_reg
   - test_sles_guestregister


### PR DESCRIPTION
Use distro refresh only for testing sles on-demand. Testing update is not necessary.

Resolves #222 