### PR TITLE
Handle HPC on-demand repos.

### DIFF
--- a/usr/share/lib/img_proof/tests/SLES/conftest.py
+++ b/usr/share/lib/img_proof/tests/SLES/conftest.py
@@ -336,6 +336,40 @@ SLE_15_SP1_SAP = [
     'SLE-Product-SLES_SAP15-SP1-Updates'
 ]
 
+SLE_15_SP1_HPC = [
+    'SLE-Product-HPC-15-SP1-Pool',
+    'SLE-Product-HPC-15-SP1-Updates',
+    'SLE-Product-HPC15-SP1-Debuginfo-Pool',
+    'SLE-Product-HPC15-SP1-Debuginfo-Updates',
+    'SLE-Product-HPC15-SP1-Source-Pool',
+    'SLE-Module-Containers15-SP1-Debuginfo-Pool',
+    'SLE-Module-Containers15-SP1-Debuginfo-Updates',
+    'SLE-Module-Containers15-SP1-Pool',
+    'SLE-Module-Containers15-SP1-Updates',
+    'SLE-Module-Desktop-Applications15-SP1-Debuginfo-Pool',
+    'SLE-Module-Desktop-Applications15-SP1-Debuginfo-Updates',
+    'SLE-Module-Desktop-Applications15-SP1-Pool',
+    'SLE-Module-Desktop-Applications15-SP1-Updates',
+    'SLE-Module-DevTools15-SP1-Debuginfo-Pool',
+    'SLE-Module-DevTools15-SP1-Debuginfo-Updates',
+    'SLE-Module-DevTools15-SP1-Pool',
+    'SLE-Module-DevTools15-SP1-Updates',
+    'SLE-Module-Public-Cloud15-SP1-Debuginfo-Pool',
+    'SLE-Module-Public-Cloud15-SP1-Debuginfo-Updates',
+    'SLE-Module-Public-Cloud15-SP1-Pool',
+    'SLE-Module-Public-Cloud15-SP1-Updates',
+    'SLE-Module-Python2-15-SP1-Pool',
+    'SLE-Module-Python2-15-SP1-Updates',
+    'SLE-Module-Server-Applications15-SP1-Debuginfo-Pool',
+    'SLE-Module-Server-Applications15-SP1-Debuginfo-Updates',
+    'SLE-Module-Server-Applications15-SP1-Pool',
+    'SLE-Module-Server-Applications15-SP1-Updates',
+    'SLE-Module-Web-Scripting15-SP1-Debuginfo-Pool',
+    'SLE-Module-Web-Scripting15-SP1-Debuginfo-Updates',
+    'SLE-Module-Web-Scripting15-SP1-Pool',
+    'SLE-Module-Web-Scripting15-SP1-Updates'
+]
+
 SLE_15_SP2_BASE = [
     'SLE-Module-Basesystem15-SP2-Debuginfo-Pool',
     'SLE-Module-Basesystem15-SP2-Debuginfo-Updates',
@@ -403,32 +437,74 @@ SLE_15_SP2_SAP = [
     'SLE-Product-SLES_SAP15-SP2-Updates'
 ]
 
+SLE_15_SP2_HPC = [
+    'SLE-Product-HPC-15-SP2-Pool',
+    'SLE-Product-HPC-15-SP2-Updates',
+    'SLE-Product-HPC15-SP2-Debuginfo-Pool',
+    'SLE-Product-HPC15-SP2-Debuginfo-Updates',
+    'SLE-Product-HPC15-SP2-Source-Pool',
+    'SLE-Module-Containers15-SP2-Debuginfo-Pool',
+    'SLE-Module-Containers15-SP2-Debuginfo-Updates',
+    'SLE-Module-Containers15-SP2-Pool',
+    'SLE-Module-Containers15-SP2-Updates',
+    'SLE-Module-Desktop-Applications15-SP2-Debuginfo-Pool',
+    'SLE-Module-Desktop-Applications15-SP2-Debuginfo-Updates',
+    'SLE-Module-Desktop-Applications15-SP2-Pool',
+    'SLE-Module-Desktop-Applications15-SP2-Updates',
+    'SLE-Module-DevTools15-SP2-Debuginfo-Pool',
+    'SLE-Module-DevTools15-SP2-Debuginfo-Updates',
+    'SLE-Module-DevTools15-SP2-Pool',
+    'SLE-Module-DevTools15-SP2-Updates',
+    'SLE-Module-Public-Cloud15-SP2-Debuginfo-Pool',
+    'SLE-Module-Public-Cloud15-SP2-Debuginfo-Updates',
+    'SLE-Module-Public-Cloud15-SP2-Pool',
+    'SLE-Module-Public-Cloud15-SP2-Updates',
+    'SLE-Module-Python2-15-SP2-Pool',
+    'SLE-Module-Python2-15-SP2-Updates',
+    'SLE-Module-Server-Applications15-SP2-Debuginfo-Pool',
+    'SLE-Module-Server-Applications15-SP2-Debuginfo-Updates',
+    'SLE-Module-Server-Applications15-SP2-Pool',
+    'SLE-Module-Server-Applications15-SP2-Updates',
+    'SLE-Module-Web-Scripting15-SP2-Debuginfo-Pool',
+    'SLE-Module-Web-Scripting15-SP2-Debuginfo-Updates',
+    'SLE-Module-Web-Scripting15-SP2-Pool',
+    'SLE-Module-Web-Scripting15-SP2-Updates'
+]
+
 BASE_15 = SLE_15_BASE + SLE_15_MODULES + SLE_15_PRODUCTS
 BASE_15_SAP = SLE_15_SAP + SLE_15_BASE + SLE_15_MODULES
 BASE_15_SP1 = SLE_15_SP1_BASE + SLE_15_SP1_MODULES + SLE_15_SP1_PRODUCTS
 BASE_15_SP1_SAP = SLE_15_SP1_SAP + SLE_15_SP1_BASE + SLE_15_SP1_MODULES
+BASE_15_SP1_HPC = SLE_15_SP1_BASE + SLE_15_SP1_HPC
 BASE_15_SP2 = SLE_15_SP2_BASE + SLE_15_SP2_MODULES + SLE_15_SP2_PRODUCTS
 BASE_15_SP2_SAP = SLE_15_SP2_SAP + SLE_15_SP2_BASE + SLE_15_SP2_MODULES
+BASE_15_SP2_HPC = SLE_15_SP2_BASE + SLE_15_SP2_HPC
 
 SLES_REPOS = {
     '11.4-X86_64': SLE_11_SP4_BASE + SLE_11_SP4_MODULES,
     '12-X86_64': SLE_12_BASE + SLE_12_MODULES,
     '12-X86_64-SAP': SLE_12_SAP + SLE_12_BASE + SLE_12_MODULES,
+    '12-X86_64-HPC': SLE_12_BASE + SLE_12_MODULES,
     '12-SP1-X86_64': SLE_12_SP1_BASE + SLE_12_SP1_MODULES,
     '12-SP1-X86_64-SAP':
         SLE_12_SP1_SAP + SLE_12_SP1_BASE + SLE_12_SP1_MODULES,
+    '12-SP1-X86_64-HPC': SLE_12_SP1_BASE + SLE_12_SP1_MODULES,
     '12-SP2-X86_64': SLE_12_SP2_BASE + SLE_12_SP2_MODULES,
     '12-SP2-X86_64-SAP':
         SLE_12_SP2_SAP + SLE_12_SP2_BASE + SLE_12_SP2_MODULES,
+    '12-SP2-X86_64-HPC': SLE_12_SP2_BASE + SLE_12_SP2_MODULES,
     '12-SP3-X86_64': SLE_12_SP3_BASE + SLE_12_SP3_MODULES,
     '12-SP3-X86_64-SAP':
         SLE_12_SP3_SAP + SLE_12_SP3_BASE + SLE_12_SP3_MODULES,
+    '12-SP3-X86_64-HPC': SLE_12_SP3_BASE + SLE_12_SP3_MODULES,
     '12-SP4-X86_64': SLE_12_SP4_BASE + SLE_12_SP4_MODULES,
     '12-SP4-X86_64-SAP':
         SLE_12_SP4_SAP + SLE_12_SP4_BASE + SLE_12_SP4_MODULES,
+    '12-SP4-X86_64-HPC': SLE_12_SP4_BASE + SLE_12_SP4_MODULES,
     '12-SP5-X86_64': SLE_12_SP5_BASE + SLE_12_SP5_MODULES,
     '12-SP5-X86_64-SAP':
         SLE_12_SP5_SAP + SLE_12_SP5_BASE + SLE_12_SP5_MODULES,
+    '12-SP5-X86_64-HPC': SLE_12_SP5_BASE + SLE_12_SP5_MODULES,
     '15-AARCH64': BASE_15,
     '15-AARCH64-SAP': BASE_15_SAP,
     '15-X86_64': BASE_15 + SLE_15_X86_64_MODULES,
@@ -437,10 +513,12 @@ SLES_REPOS = {
     '15-SP1-AARCH64-SAP': BASE_15_SP1_SAP,
     '15-SP1-X86_64': BASE_15_SP1 + SLE_15_SP1_X86_64_MODULES,
     '15-SP1-X86_64-SAP': BASE_15_SP1_SAP + SLE_15_SP1_X86_64_MODULES,
+    '15-SP1-X86_64-HPC': BASE_15_SP1_HPC,
     '15-SP2-AARCH64': BASE_15_SP2,
     '15-SP2-AARCH64-SAP': BASE_15_SP2_SAP,
     '15-SP2-X86_64': BASE_15_SP2 + SLE_15_SP2_X86_64_MODULES,
     '15-SP2-X86_64-SAP': BASE_15_SP2_SAP + SLE_15_SP2_X86_64_MODULES,
+    '15-SP2-X86_64-HPC': BASE_15_SP2_HPC,
 }
 
 

--- a/usr/share/lib/img_proof/tests/SLES/test_sles_repos.py
+++ b/usr/share/lib/img_proof/tests/SLES/test_sles_repos.py
@@ -5,14 +5,16 @@ def test_sles_repos(
     get_instance_repos,
     get_release_value,
     get_sles_repos,
-    is_sles_sap,
+    get_baseproduct,
     determine_architecture
 ):
     version = [get_release_value('VERSION'), determine_architecture()]
 
-    sap = is_sles_sap()
-    if sap:
+    product = get_baseproduct()
+    if 'sap' in product.lower():
         version.append('SAP')
+    if 'hpc' in product.lower():
+        version.append('HPC')
 
     version = '-'.join(version)
 


### PR DESCRIPTION
HPC for SLES15 has a different set of repos then base SLES. Create a new list for HPC images to test against.

This is not the ideal fix as that would be changing the tests to check products rather than repos. But this is sufficient get the HPC tests for SLE15 running properly.