### PR TITLE
Add timestamp to file log handler.

### DIFF
--- a/img_proof/ipa_azure.py
+++ b/img_proof/ipa_azure.py
@@ -48,7 +48,7 @@ class AzureCloud(IpaCloud):
         image_id=None,
         inject=None,
         instance_type=None,
-        log_level=30,
+        log_level=None,
         no_default_test_dirs=False,
         cloud_config=None,
         region=None,

--- a/img_proof/ipa_cloud.py
+++ b/img_proof/ipa_cloud.py
@@ -83,7 +83,7 @@ class IpaCloud(object):
         image_id=None,
         inject=None,
         instance_type=None,
-        log_level=30,
+        log_level=None,
         no_default_test_dirs=False,
         cloud_config=None,
         region=None,
@@ -425,7 +425,9 @@ class IpaCloud(object):
         # Add log file handler
         file_handler = logging.FileHandler(self.log_file)
         file_handler.setLevel(logging.DEBUG)
-        file_handler.setFormatter(logging.Formatter('\n%(message)s\n'))
+        file_handler.setFormatter(
+            logging.Formatter('\n%(asctime)s: %(message)s\n')
+        )
         self.logger.addHandler(file_handler)
 
     def _start_instance(self):

--- a/img_proof/ipa_ec2.py
+++ b/img_proof/ipa_ec2.py
@@ -52,7 +52,7 @@ class EC2Cloud(IpaCloud):
         image_id=None,
         inject=None,
         instance_type=None,
-        log_level=30,
+        log_level=None,
         no_default_test_dirs=False,
         cloud_config=None,
         region=None,

--- a/img_proof/ipa_gce.py
+++ b/img_proof/ipa_gce.py
@@ -55,7 +55,7 @@ class GCECloud(IpaCloud):
         image_id=None,
         inject=None,
         instance_type=None,
-        log_level=30,
+        log_level=None,
         no_default_test_dirs=False,
         cloud_config=None,
         region=None,

--- a/img_proof/ipa_oci.py
+++ b/img_proof/ipa_oci.py
@@ -45,7 +45,7 @@ class OCICloud(IpaCloud):
         image_id=None,
         inject=None,
         instance_type=None,
-        log_level=30,
+        log_level=None,
         no_default_test_dirs=False,
         cloud_config=None,
         region=None,


### PR DESCRIPTION
Remove default log level from class signatures. This overrides the default in base ipa_cloud class and they didn't match.