### PR TITLE
Ensure region hint is in cloudregister log.

### DIFF
--- a/usr/share/lib/img_proof/tests/SLES/test_sles_smt_reg.py
+++ b/usr/share/lib/img_proof/tests/SLES/test_sles_smt_reg.py
@@ -1,15 +1,19 @@
 import shlex
 
 
-def test_sles_smt_reg(check_cloud_register,
-                      determine_provider,
-                      get_smt_server_name,
-                      get_smt_servers,
-                      host):
+def test_sles_smt_reg(
+    check_cloud_register,
+    determine_provider,
+    get_smt_server_name,
+    get_smt_servers,
+    host
+):
     provider = determine_provider()
 
+    # ensure instance registered successfully
     assert check_cloud_register()
 
+    # ensure the correct smt/rmt ip is used
     servers = get_smt_servers(provider)
     smt_ips = [server['ip'] for server in servers]
 
@@ -19,3 +23,9 @@ def test_sles_smt_reg(check_cloud_register,
     smt_ip = shlex.split(result.stdout)[0]
 
     assert smt_ip in smt_ips
+
+    # ensure region hint is in log
+    cloud_register_log = host.file('/var/log/cloudregister')
+    assert cloud_register_log.contains(
+        'INFO:Region server arguments: ?regionHint='
+    )


### PR DESCRIPTION
For on-demand SLES image tests.