### PR TITLE
Use post init workflow.

### DIFF
--- a/img_proof/ipa_azure.py
+++ b/img_proof/ipa_azure.py
@@ -35,76 +35,18 @@ from img_proof.ipa_cloud import IpaCloud
 
 class AzureCloud(IpaCloud):
     """Class for testing instances in Azure."""
+    cloud = 'azure'
 
-    def __init__(
-        self,
-        accelerated_networking=False,
-        cleanup=None,
-        config=None,
-        description=None,
-        distro_name=None,
-        early_exit=None,
-        history_log=None,
-        image_id=None,
-        inject=None,
-        instance_type=None,
-        log_level=None,
-        no_default_test_dirs=None,
-        cloud_config=None,
-        region=None,
-        results_dir=None,
-        running_instance_id=None,
-        service_account_file=None,
-        ssh_private_key_file=None,
-        ssh_user=None,
-        subnet_id=None,
-        test_dirs=None,
-        test_files=None,
-        timeout=None,
-        vnet_name=None,
-        vnet_resource_group=None,
-        collect_vm_info=None,
-        enable_secure_boot=None,
-        enable_uefi=None,
-        log_callback=None,
-        prefix_name=None,
-        retry_count=None
-    ):
-        """Initialize Azure Cloud class."""
-        super(AzureCloud, self).__init__(
-            'azure',
-            cleanup,
-            config,
-            description,
-            distro_name,
-            early_exit,
-            history_log,
-            image_id,
-            inject,
-            instance_type,
-            log_level,
-            no_default_test_dirs,
-            cloud_config,
-            region,
-            results_dir,
-            running_instance_id,
-            test_dirs,
-            test_files,
-            timeout,
-            collect_vm_info,
-            ssh_private_key_file,
-            ssh_user,
-            subnet_id,
-            enable_secure_boot,
-            enable_uefi,
-            log_callback,
-            prefix_name,
-            retry_count
+    def post_init(self):
+        """Initialize Azure cloud framework class."""
+
+        self.vnet_name = (
+                self.custom_args.get('vnet_name')
+                or self.ipa_config['vnet_name']
         )
-
-        self.vnet_name = vnet_name or self.ipa_config['vnet_name']
         self.vnet_resource_group = (
-                vnet_resource_group or self.ipa_config['vnet_resource_group']
+            self.custom_args.get('vnet_resource_group')
+            or self.ipa_config['vnet_resource_group']
         )
 
         subnet_args = [
@@ -117,7 +59,8 @@ class AzureCloud(IpaCloud):
             )
 
         self.service_account_file = (
-            service_account_file or self.ipa_config['service_account_file']
+            self.custom_args.get('service_account_file')
+            or self.ipa_config['service_account_file']
         )
         if not self.service_account_file:
             raise AzureCloudException(
@@ -134,8 +77,8 @@ class AzureCloud(IpaCloud):
             )
 
         self.accelerated_networking = (
-            accelerated_networking or
-            self.ipa_config['accelerated_networking']
+            self.custom_args.get('accelerated_networking')
+            or self.ipa_config['accelerated_networking']
         )
         self.ssh_user = self.ssh_user or AZURE_DEFAULT_USER
         self.ssh_public_key = self._get_ssh_public_key()

--- a/img_proof/ipa_cloud.py
+++ b/img_proof/ipa_cloud.py
@@ -73,10 +73,10 @@ class IpaCloud(object):
     modules extend the base class and implement cloud
     specific methods for launching and managing instances.
     """
+    cloud = 'base'
 
     def __init__(
         self,
-        cloud,
         cleanup=None,
         config=None,
         description=None,
@@ -103,7 +103,8 @@ class IpaCloud(object):
         enable_uefi=None,
         log_callback=None,
         prefix_name=None,
-        retry_count=None
+        retry_count=None,
+        custom_args=None
     ):
         """Initialize base cloud framework class."""
         super(IpaCloud, self).__init__()
@@ -112,7 +113,7 @@ class IpaCloud(object):
 
         ipa_utils.clear_cache()
 
-        self.cloud = cloud
+        self.custom_args = custom_args if custom_args else {}
         self.host_key_fingerprint = None
         self.instance_ip = None
 
@@ -204,6 +205,10 @@ class IpaCloud(object):
         }
 
         self._parse_test_files(test_dirs, self.no_default_test_dirs)
+        self.post_init()
+
+    def post_init(self):
+        pass
 
     def _get_instance(self):
         raise NotImplementedError(NOT_IMPLEMENTED)

--- a/img_proof/ipa_controller.py
+++ b/img_proof/ipa_controller.py
@@ -116,43 +116,41 @@ def test_image(
 
     cloud_name = cloud_name.lower()
     if cloud_name == 'azure':
-        cloud = AzureCloud(
-            accelerated_networking=accelerated_networking,
-            service_account_file=service_account_file,
-            vnet_name=vnet_name,
-            vnet_resource_group=vnet_resource_group,
-            **kwargs
-        )
+        kwargs['custom_args'] = {
+            'accelerated_networking': accelerated_networking,
+            'service_account_file': service_account_file,
+            'vnet_name': vnet_name,
+            'vnet_resource_group': vnet_resource_group
+        }
+        cloud = AzureCloud(**kwargs)
     elif cloud_name == 'ec2':
-        cloud = EC2Cloud(
-            access_key_id=access_key_id,
-            account_name=account,
-            secret_access_key=secret_access_key,
-            security_group_id=security_group_id,
-            ssh_key_name=ssh_key_name,
-            **kwargs
-        )
+        kwargs['custom_args'] = {
+            'access_key_id': access_key_id,
+            'account_name': account,
+            'secret_access_key': secret_access_key,
+            'security_group_id': security_group_id,
+            'ssh_key_name': ssh_key_name
+        }
+        cloud = EC2Cloud(**kwargs)
     elif cloud_name == 'gce':
-        cloud = GCECloud(
-            service_account_file=service_account_file,
-            image_project=image_project,
-            **kwargs
-        )
+        kwargs['custom_args'] = {
+            'service_account_file': service_account_file,
+            'image_project': image_project
+        }
+        cloud = GCECloud(**kwargs)
     elif cloud_name == 'ssh':
-        cloud = SSHCloud(
-            ip_address=ip_address,
-            **kwargs
-        )
+        kwargs['custom_args'] = {'ip_address': ip_address}
+        cloud = SSHCloud(**kwargs)
     elif cloud_name == 'oci':
-        cloud = OCICloud(
-            compartment_id=compartment_id,
-            availability_domain=availability_domain,
-            signing_key_fingerprint=signing_key_fingerprint,
-            signing_key_file=signing_key_file,
-            tenancy=tenancy,
-            oci_user_id=oci_user_id,
-            **kwargs
-        )
+        kwargs['custom_args'] = {
+            'compartment_id': compartment_id,
+            'availability_domain': availability_domain,
+            'signing_key_fingerprint': signing_key_fingerprint,
+            'signing_key_file': signing_key_file,
+            'tenancy': tenancy,
+            'oci_user_id': oci_user_id
+        }
+        cloud = OCICloud(**kwargs)
     else:
         raise IpaControllerException(
             'Cloud framework: %s unavailable.' % cloud_name

--- a/img_proof/ipa_ec2.py
+++ b/img_proof/ipa_ec2.py
@@ -38,78 +38,16 @@ from img_proof.ipa_cloud import IpaCloud
 
 class EC2Cloud(IpaCloud):
     """Cloud framework class for testing AWS EC2 images."""
+    cloud = 'ec2'
 
-    def __init__(
-        self,
-        access_key_id=None,
-        account_name=None,
-        cleanup=None,
-        config=None,
-        description=None,
-        distro_name=None,
-        early_exit=None,
-        history_log=None,
-        image_id=None,
-        inject=None,
-        instance_type=None,
-        log_level=None,
-        no_default_test_dirs=None,
-        cloud_config=None,
-        region=None,
-        results_dir=None,
-        running_instance_id=None,
-        secret_access_key=None,
-        security_group_id=None,
-        ssh_key_name=None,
-        ssh_private_key_file=None,
-        ssh_user=None,
-        subnet_id=None,
-        test_dirs=None,
-        test_files=None,
-        timeout=None,
-        collect_vm_info=None,
-        enable_secure_boot=None,
-        enable_uefi=None,
-        log_callback=None,
-        prefix_name=None,
-        retry_count=None
-    ):
+    def post_init(self):
         """Initialize EC2 cloud framework class."""
-        super(EC2Cloud, self).__init__(
-            'ec2',
-            cleanup,
-            config,
-            description,
-            distro_name,
-            early_exit,
-            history_log,
-            image_id,
-            inject,
-            instance_type,
-            log_level,
-            no_default_test_dirs,
-            cloud_config,
-            region,
-            results_dir,
-            running_instance_id,
-            test_dirs,
-            test_files,
-            timeout,
-            collect_vm_info,
-            ssh_private_key_file,
-            ssh_user,
-            subnet_id,
-            enable_secure_boot,
-            enable_uefi,
-            log_callback,
-            prefix_name,
-            retry_count
-        )
+
         # Get command line values that are not None
-        cmd_line_values = self._get_non_null_values(locals())
+        cmd_line_values = self._get_non_null_values(self.custom_args)
 
         self.zone = None
-        self.account_name = account_name
+        self.account_name = self.custom_args.get('account_name')
 
         if not self.account_name:
             self.logger.debug(

--- a/img_proof/ipa_gce.py
+++ b/img_proof/ipa_gce.py
@@ -81,72 +81,13 @@ class GCECloud(IpaCloud):
     """
     Cloud framework class for testing Google Compute Engine (GCE) images.
     """
+    cloud = 'gce'
 
-    def __init__(
-        self,
-        cleanup=None,
-        config=None,
-        description=None,
-        distro_name=None,
-        early_exit=None,
-        history_log=None,
-        image_id=None,
-        inject=None,
-        instance_type=None,
-        log_level=None,
-        no_default_test_dirs=None,
-        cloud_config=None,
-        region=None,
-        results_dir=None,
-        running_instance_id=None,
-        service_account_file=None,
-        ssh_private_key_file=None,
-        ssh_user=None,
-        subnet_id=None,
-        test_dirs=None,
-        test_files=None,
-        timeout=None,
-        collect_vm_info=None,
-        image_project=None,
-        enable_secure_boot=None,
-        enable_uefi=None,
-        log_callback=None,
-        prefix_name=None,
-        retry_count=None
-    ):
-        super(GCECloud, self).__init__(
-            'gce',
-            cleanup,
-            config,
-            description,
-            distro_name,
-            early_exit,
-            history_log,
-            image_id,
-            inject,
-            instance_type,
-            log_level,
-            no_default_test_dirs,
-            cloud_config,
-            region,
-            results_dir,
-            running_instance_id,
-            test_dirs,
-            test_files,
-            timeout,
-            collect_vm_info,
-            ssh_private_key_file,
-            ssh_user,
-            subnet_id,
-            enable_secure_boot,
-            enable_uefi,
-            log_callback,
-            prefix_name,
-            retry_count
-        )
+    def post_init(self):
+        """Initialize EC2 cloud framework class."""
 
         self.service_account_file = (
-            service_account_file or
+            self.custom_args.get('service_account_file') or
             self.ipa_config['service_account_file']
         )
         if not self.service_account_file:
@@ -165,7 +106,7 @@ class GCECloud(IpaCloud):
 
         self.ssh_user = self.ssh_user or GCE_DEFAULT_USER
         self.ssh_public_key = self._get_ssh_public_key()
-        self.image_project = image_project
+        self.image_project = self.custom_args.get('image_project')
 
         self.credentials = self._get_credentials()
         self.compute_driver = self._get_driver()

--- a/img_proof/ipa_oci.py
+++ b/img_proof/ipa_oci.py
@@ -33,77 +33,14 @@ from img_proof.ipa_cloud import IpaCloud
 
 class OCICloud(IpaCloud):
     """Cloud framework class for testing Oracle OCI images."""
+    cloud = 'oci'
 
-    def __init__(
-        self,
-        cleanup=None,
-        config=None,
-        description=None,
-        distro_name=None,
-        early_exit=None,
-        history_log=None,
-        image_id=None,
-        inject=None,
-        instance_type=None,
-        log_level=None,
-        no_default_test_dirs=None,
-        cloud_config=None,
-        region=None,
-        results_dir=None,
-        running_instance_id=None,
-        ssh_private_key_file=None,
-        ssh_user=None,
-        subnet_id=None,
-        test_dirs=None,
-        test_files=None,
-        timeout=None,
-        collect_vm_info=None,
-        compartment_id=None,
-        availability_domain=None,
-        signing_key_fingerprint=None,
-        signing_key_file=None,
-        tenancy=None,
-        oci_user_id=None,
-        enable_secure_boot=None,
-        enable_uefi=None,
-        log_callback=None,
-        prefix_name=None,
-        retry_count=None
-    ):
+    def post_init(self):
         """Initialize OCI cloud framework class."""
-        super(OCICloud, self).__init__(
-            'oci',
-            cleanup,
-            config,
-            description,
-            distro_name,
-            early_exit,
-            history_log,
-            image_id,
-            inject,
-            instance_type,
-            log_level,
-            no_default_test_dirs,
-            cloud_config,
-            region,
-            results_dir,
-            running_instance_id,
-            test_dirs,
-            test_files,
-            timeout,
-            collect_vm_info,
-            ssh_private_key_file,
-            ssh_user,
-            subnet_id,
-            enable_secure_boot,
-            enable_uefi,
-            log_callback,
-            prefix_name,
-            retry_count
-        )
 
         self.availability_domain = (
-            availability_domain or self.ipa_config['availability_domain']
+            self.custom_args.get('availability_domain')
+            or self.ipa_config['availability_domain']
         )
 
         if not self.availability_domain:
@@ -112,7 +49,8 @@ class OCICloud(IpaCloud):
             )
 
         self.compartment_id = (
-            compartment_id or self.ipa_config['compartment_id']
+            self.custom_args.get('compartment_id')
+            or self.ipa_config['compartment_id']
         )
 
         if not self.compartment_id:
@@ -126,15 +64,20 @@ class OCICloud(IpaCloud):
             )
 
         self.ssh_user = self.ssh_user or OCI_DEFAULT_USER
-        self.subnet_id = subnet_id or self.ipa_config['subnet_id']
-        self.oci_user_id = oci_user_id or self.ipa_config['oci_user_id']
-        self.tenancy = tenancy or self.ipa_config['tenancy']
+        self.oci_user_id = (
+            self.custom_args.get('oci_user_id')
+            or self.ipa_config['oci_user_id']
+        )
+        self.tenancy = (
+            self.custom_args.get('tenancy') or self.ipa_config['tenancy']
+        )
         self.signing_key_fingerprint = (
-            signing_key_fingerprint
+            self.custom_args.get('signing_key_fingerprint')
             or self.ipa_config['signing_key_fingerprint']
         )
         self.signing_key_file = (
-            signing_key_file or self.ipa_config['signing_key_file']
+            self.custom_args.get('signing_key_file')
+            or self.ipa_config['signing_key_file']
         )
 
         config = self._get_config()

--- a/img_proof/ipa_ssh.py
+++ b/img_proof/ipa_ssh.py
@@ -26,69 +26,19 @@ from img_proof.ipa_cloud import IpaCloud
 
 class SSHCloud(IpaCloud):
     """Class for testing instances in Azure."""
+    cloud = 'ssh'
 
-    def __init__(
-        self,
-        cleanup=None,
-        config=None,
-        description=None,
-        distro_name=None,
-        early_exit=None,
-        history_log=None,
-        image_id=None,  # Not used in SSH
-        inject=None,
-        instance_type=None,  # Not used in SSH
-        ip_address=None,
-        log_level=30,
-        no_default_test_dirs=False,
-        cloud_config=None,
-        region=None,  # Not used in SSH
-        results_dir=None,
-        running_instance_id=None,  # Not used in SSH
-        ssh_private_key_file=None,
-        ssh_user=None,
-        subnet_id=None,  # Not used in SSH
-        test_dirs=None,
-        test_files=None,
-        timeout=None,
-        collect_vm_info=None
-    ):
-        """Initialize Azure cloud class."""
-        super(SSHCloud, self).__init__(
-            'ssh',
-            cleanup,
-            config,
-            description,
-            distro_name,
-            early_exit,
-            history_log,
-            image_id,
-            inject,
-            instance_type,
-            log_level,
-            no_default_test_dirs,
-            cloud_config,
-            region,
-            results_dir,
-            running_instance_id,
-            test_dirs,
-            test_files,
-            timeout,
-            collect_vm_info,
-            ssh_private_key_file,
-            ssh_user,
-            subnet_id
-        )
+    def post_init(self):
+        """Initialize SSH cloud class."""
 
         # Cannot cleanup SSH instance
         self.cleanup = False
+        self.instance_ip = self.custom_args.get('ip_address')
 
-        if not ip_address:
+        if not self.instance_ip:
             raise SSHCloudException(
                 'IP address is required to connect to instance.'
             )
-        else:
-            self.instance_ip = ip_address
 
         if not self.ssh_private_key_file:
             raise SSHCloudException(

--- a/tests/test_ipa_azure.py
+++ b/tests/test_ipa_azure.py
@@ -43,10 +43,12 @@ class TestAzureProvider(object):
             'image_id': 'another:fake:image:id',
             'no_default_test_dirs': True,
             'running_instance_id': 'fakeinstance',
-            'service_account_file': 'tests/azure/test-sa.json',
             'ssh_private_key_file': 'tests/data/ida_test',
             'test_dirs': 'tests/data/tests',
-            'test_files': ['test_image']
+            'test_files': ['test_image'],
+            'custom_args': {
+                'service_account_file': 'tests/azure/test-sa.json'
+            }
         }
 
     @patch.object(AzureCloud, '_get_management_client')

--- a/tests/test_ipa_cloud.py
+++ b/tests/test_ipa_cloud.py
@@ -33,8 +33,6 @@ from img_proof.ipa_cloud import IpaCloud
 from unittest.mock import call, MagicMock, patch
 from tempfile import TemporaryDirectory
 
-args = ['ec2']
-
 NOT_IMPL_METHODS = [
     '_get_instance',
     '_get_instance_state',
@@ -83,7 +81,7 @@ class TestIpaCloud(object):
     )
     def test_cloud_not_implemented_methods(self, method):
         """Confirm methods raise not implemented exception."""
-        cloud = IpaCloud(*args, **self.kwargs)
+        cloud = IpaCloud(**self.kwargs)
 
         with pytest.raises(NotImplementedError) as error:
             getattr(cloud, method)()
@@ -92,7 +90,7 @@ class TestIpaCloud(object):
     def test_cloud_distro_required(self):
         """Test exception raised if no distro provided."""
         with pytest.raises(IpaCloudException) as error:
-            IpaCloud(*args, config='tests/data/config')
+            IpaCloud(config='tests/data/config')
 
         assert str(error.value) == \
             'Distro name is required.'
@@ -101,7 +99,6 @@ class TestIpaCloud(object):
         """Test exception if no running instance or image id provided."""
         with pytest.raises(IpaCloudException) as error:
             IpaCloud(
-                *args,
                 config='tests/data/config',
                 distro_name='SLES'
             )
@@ -112,7 +109,7 @@ class TestIpaCloud(object):
     @patch.object(ipa_utils, 'get_ssh_client')
     def test_cloud_get_ssh_client(self, mock_get_ssh_client):
         """Test get ssh client method."""
-        cloud = IpaCloud(*args, **self.kwargs)
+        cloud = IpaCloud(**self.kwargs)
 
         cloud.instance_ip = '127.0.0.1'
         cloud.ssh_user = 'ec2-user'
@@ -131,7 +128,7 @@ class TestIpaCloud(object):
     def test_cloud_get_user_data(self, mock_get_ssh_key):
         mock_get_ssh_key.return_value = b'testkey12345'
 
-        provider = IpaCloud(*args, **self.kwargs)
+        provider = IpaCloud(**self.kwargs)
 
         result = provider._get_user_data()
 
@@ -141,7 +138,7 @@ class TestIpaCloud(object):
 
     def test_cloud_get_non_null_values(self):
         """Test cloud get non null values method."""
-        cloud = IpaCloud(*args, **self.kwargs)
+        cloud = IpaCloud(**self.kwargs)
 
         data = {'region': 'us-east-1', 'type': None}
 
@@ -152,7 +149,7 @@ class TestIpaCloud(object):
 
     def test_cloud_merge_results(self):
         """Test merge results output."""
-        cloud = IpaCloud(*args, **self.kwargs)
+        cloud = IpaCloud(**self.kwargs)
 
         results = {
             "tests": [
@@ -184,7 +181,7 @@ class TestIpaCloud(object):
             assert cloud.results['tests'][0][key] == val
 
     def test_process_test_results(self):
-        cloud = IpaCloud(*args, **self.kwargs)
+        cloud = IpaCloud(**self.kwargs)
         cloud._process_test_results(5.0, 'test_test')
 
         assert cloud.results['summary']['duration'] == 5.0
@@ -202,7 +199,7 @@ class TestIpaCloud(object):
         mock_pytest.return_value = 0
         mock_merge_results.return_value = None
 
-        cloud = IpaCloud(*args, **self.kwargs)
+        cloud = IpaCloud(**self.kwargs)
 
         cloud.terminate = True
         cloud.results['info'] = {
@@ -220,7 +217,7 @@ class TestIpaCloud(object):
 
     def test_cloud_invalid_distro_name(self):
         """Test invalid distro name provided raises exception."""
-        cloud = IpaCloud(*args, **self.kwargs)
+        cloud = IpaCloud(**self.kwargs)
         cloud.distro_name = 'BadDistro'
 
         with pytest.raises(IpaCloudException) as error:
@@ -238,7 +235,7 @@ class TestIpaCloud(object):
         mock_instance_running.return_value = False
         mock_start_instance.return_value = None
 
-        cloud = IpaCloud(*args, **self.kwargs)
+        cloud = IpaCloud(**self.kwargs)
         cloud._start_instance_if_stopped()
 
         assert mock_instance_running.call_count == 1
@@ -249,7 +246,7 @@ class TestIpaCloud(object):
         client = MagicMock()
         mock_exec_cmd.return_value = 'command executed successfully!'
 
-        cloud = IpaCloud(*args, **self.kwargs)
+        cloud = IpaCloud(**self.kwargs)
         cloud.log_file = 'fake_file.name'
 
         with patch('builtins.open', create=True) as mock_open:
@@ -269,7 +266,7 @@ class TestIpaCloud(object):
 
         mock_extract_archive.return_value = 'archive extracted successfully!'
 
-        cloud = IpaCloud(*args, **self.kwargs)
+        cloud = IpaCloud(**self.kwargs)
         cloud.log_file = 'fake_file.name'
 
         with patch('builtins.open', create=True) as mock_open:
@@ -301,7 +298,7 @@ class TestIpaCloud(object):
         mock_start_instance.return_value = None
         mock_set_instance_ip.return_value = None
 
-        cloud = IpaCloud(*args, **self.kwargs)
+        cloud = IpaCloud(**self.kwargs)
         cloud.instance_ip = '0.0.0.0'
         cloud.hard_reboot_instance()
 
@@ -316,7 +313,7 @@ class TestIpaCloud(object):
         file_path = '/home/user/test.file'
         basename = 'test.file'
 
-        cloud = IpaCloud(*args, **self.kwargs)
+        cloud = IpaCloud(**self.kwargs)
         out = cloud.put_file(client, file_path)
 
         assert out == basename
@@ -330,7 +327,7 @@ class TestIpaCloud(object):
         distro = MagicMock()
         distro.install_package.return_value = 'package install successful!'
 
-        cloud = IpaCloud(*args, **self.kwargs)
+        cloud = IpaCloud(**self.kwargs)
         cloud.log_file = 'fake_file.name'
         cloud.distro = distro
 
@@ -361,7 +358,7 @@ class TestIpaCloud(object):
             'test.noarch.rpm', 'test.tar.xz', 'test.py'
         ]
 
-        cloud = IpaCloud(*args, **self.kwargs)
+        cloud = IpaCloud(**self.kwargs)
         cloud.inject = 'tests/data/injection/test_injection.yaml'
 
         cloud.process_injection_file(client)
@@ -406,7 +403,7 @@ class TestIpaCloud(object):
         mock_get_console_log.return_value = 'Console log output...'
         self.kwargs['running_instance_id'] = 'fakeinstance'
 
-        cloud = IpaCloud(*args, **self.kwargs)
+        cloud = IpaCloud(**self.kwargs)
         with pytest.raises(IpaCloudException) as error:
             cloud.test_image()
         assert str(error.value) == 'Unable to connect to instance: ERROR!'
@@ -437,7 +434,7 @@ class TestIpaCloud(object):
         self.kwargs['running_instance_id'] = 'fakeinstance'
         self.kwargs['test_files'] = ['test_hard_reboot']
 
-        cloud = IpaCloud(*args, **self.kwargs)
+        cloud = IpaCloud(**self.kwargs)
         cloud.ssh_private_key_file = 'tests/data/ida_test'
         cloud.ssh_user = 'root'
         cloud.logger = MagicMock()
@@ -494,7 +491,7 @@ class TestIpaCloud(object):
         self.kwargs['running_instance_id'] = 'fakeinstance'
         self.kwargs['test_files'] = ['test_soft_reboot']
 
-        cloud = IpaCloud(*args, **self.kwargs)
+        cloud = IpaCloud(**self.kwargs)
         cloud.ssh_private_key_file = 'tests/data/ida_test'
         cloud.ssh_user = 'root'
         cloud.logger = MagicMock()
@@ -551,7 +548,7 @@ class TestIpaCloud(object):
         self.kwargs['test_files'] = ['test_update']
         self.kwargs['cleanup'] = True
 
-        cloud = IpaCloud(*args, **self.kwargs)
+        cloud = IpaCloud(**self.kwargs)
         cloud.ssh_private_key_file = 'tests/data/ida_test'
         cloud.ssh_user = 'root'
 
@@ -589,7 +586,7 @@ class TestIpaCloud(object):
         self.kwargs['test_files'] = ['test_refresh']
         self.kwargs['cleanup'] = True
 
-        cloud = IpaCloud(*args, **self.kwargs)
+        cloud = IpaCloud(**self.kwargs)
         cloud.ssh_private_key_file = 'tests/data/ida_test'
         cloud.ssh_user = 'root'
 
@@ -623,7 +620,7 @@ class TestIpaCloud(object):
         self.kwargs['running_instance_id'] = 'fakeinstance'
         self.kwargs['early_exit'] = True
 
-        cloud = IpaCloud(*args, **self.kwargs)
+        cloud = IpaCloud(**self.kwargs)
         cloud.ssh_private_key_file = 'tests/data/ida_test'
         cloud.ssh_user = 'root'
 
@@ -640,7 +637,7 @@ class TestIpaCloud(object):
         mock_get_instance_state.return_value = 'Stopped'
         mock_sleep.return_value = None
 
-        cloud = IpaCloud(*args, **self.kwargs)
+        cloud = IpaCloud(**self.kwargs)
         cloud._wait_on_instance('Stopped')
         assert mock_get_instance_state.call_count == 1
 
@@ -653,7 +650,7 @@ class TestIpaCloud(object):
             'Failed to collect VM info: Does not exist.'
         mock_get_ssh_client.return_value = client
 
-        cloud = IpaCloud(*args, **self.kwargs)
+        cloud = IpaCloud(**self.kwargs)
         cloud.distro = distro
         cloud.log_file = 'fake_file.name'
         cloud.logger = MagicMock()

--- a/tests/test_ipa_ec2.py
+++ b/tests/test_ipa_ec2.py
@@ -36,14 +36,16 @@ class TestEC2Provider(object):
     def setup_method(self, method):
         """Set up kwargs dict."""
         self.kwargs = {
-            'account_name': 'bob',
             'config': 'tests/data/config',
             'distro_name': 'SLES',
             'image_id': 'fakeimage',
             'no_default_test_dirs': True,
             'cloud_config': 'tests/ec2/.ec2utils.conf',
             'test_files': ['test_image'],
-            'ssh_key_name': 'test-key'
+            'custom_args': {
+                'account_name': 'bob',
+                'ssh_key_name': 'test-key'
+            }
         }
 
     def test_ec2_exception_required_args(self):

--- a/tests/test_ipa_gce.py
+++ b/tests/test_ipa_gce.py
@@ -64,9 +64,11 @@ class TestGCECloud(object):
             'distro_name': 'SLES',
             'image_id': 'fakeimage',
             'no_default_test_dirs': True,
-            'service_account_file': 'tests/gce/service-account.json',
             'ssh_private_key_file': 'tests/data/ida_test',
-            'test_files': ['test_image']
+            'test_files': ['test_image'],
+            'custom_args': {
+                'service_account_file': 'tests/gce/service-account.json'
+            }
         }
 
         driver = MagicMock()
@@ -80,7 +82,7 @@ class TestGCECloud(object):
 
     def test_gce_exception_required_args(self):
         """Test an exception is raised if required args missing."""
-        self.kwargs['service_account_file'] = None
+        self.kwargs['custom_args']['service_account_file'] = None
         self.kwargs['ssh_private_key_file'] = None
 
         # Test service account file required
@@ -90,7 +92,8 @@ class TestGCECloud(object):
         assert str(error.value) == \
             'Service account file is required to connect to GCE.'
 
-        self.kwargs['service_account_file'] = 'tests/gce/service-account.json'
+        self.kwargs['custom_args']['service_account_file'] = \
+            'tests/gce/service-account.json'
 
         # Test ssh private key file required
         with pytest.raises(GCECloudException) as error:

--- a/tests/test_ipa_oci.py
+++ b/tests/test_ipa_oci.py
@@ -41,15 +41,19 @@ class TestOCIProvider(object):
             'no_default_test_dirs': True,
             'cloud_config': 'tests/oci/config',
             'test_files': ['test_image'],
-            'oci_user_id':
-                'ocid1.user.oc1..'
-                'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-            'signing_key_fingerprint':
-                '00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00',
-            'signing_key_file': 'tests/oci/api_key.pem',
-            'tenancy':
-                'ocid1.tenancy.oc1..'
-                'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+            'custom_args': {
+                'oci_user_id':
+                    'ocid1.user.oc1..'
+                    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+                    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+                'signing_key_fingerprint':
+                    '00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00',
+                'signing_key_file': 'tests/oci/api_key.pem',
+                'tenancy':
+                    'ocid1.tenancy.oc1..'
+                    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+                    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+            }
         }
 
     def test_oci_exception_required_args(self):
@@ -58,13 +62,13 @@ class TestOCIProvider(object):
         with pytest.raises(OCICloudException):
             OCICloud(**self.kwargs)
 
-        self.kwargs['availability_domain'] = 'Omic:PHX-AD-1'
+        self.kwargs['custom_args']['availability_domain'] = 'Omic:PHX-AD-1'
 
         # Test missing compartment id
         with pytest.raises(OCICloudException):
             OCICloud(**self.kwargs)
 
-        self.kwargs['compartment_id'] = (
+        self.kwargs['custom_args']['compartment_id'] = (
             'ocid1.compartment.oc1..'
             'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
         )
@@ -83,8 +87,8 @@ class TestOCIProvider(object):
         mock_oci.core.VirtualNetworkClient.return_value = client
         mock_oci.core.VirtualNetworkClientCompsiteOperations.return_value = client  # noqa
 
-        self.kwargs['availability_domain'] = 'Omic:PHX-AD-1'
-        self.kwargs['compartment_id'] = (
+        self.kwargs['custom_args']['availability_domain'] = 'Omic:PHX-AD-1'
+        self.kwargs['custom_args']['compartment_id'] = (
             'ocid1.compartment.oc1..'
             'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
         )

--- a/tests/test_ipa_ssh.py
+++ b/tests/test_ipa_ssh.py
@@ -35,12 +35,12 @@ class TestSSHProvider(object):
         self.kwargs = {
             'config': 'tests/data/config',
             'distro_name': 'sles',
-            'ip_address': '10.0.0.1',
             'no_default_test_dirs': True,
             'ssh_private_key_file': 'tests/data/ida_test',
             'ssh_user': 'root',
             'test_dirs': 'tests/data/tests',
-            'test_files': ['test_image']
+            'test_files': ['test_image'],
+            'custom_args': {'ip_address': '10.0.0.1'}
         }
 
     @pytest.mark.parametrize('name,msg', [
@@ -48,8 +48,7 @@ class TestSSHProvider(object):
         (
             'ssh_private_key_file',
             'SSH private key file is required to connect to instance.'
-        ),
-        ('ip_address', 'IP address is required to connect to instance.')
+        )
     ])
     def test_required_args(self, name, msg):
         self.kwargs[name] = None


### PR DESCRIPTION
Fix regression with latest secure boot args missing from ssh backend. And prevent future regressions by using post init workflow.

Resolves #260 