### PR TITLE
Create empty console log method for ssh backend.

### DIFF
--- a/img_proof/ipa_ssh.py
+++ b/img_proof/ipa_ssh.py
@@ -120,6 +120,12 @@ class SSHCloud(IpaCloud):
         """
         pass
 
+    def get_console_log(self):
+        """
+        Return console log output if it is available.
+        """
+        return ''  # No console log for SSH backend
+
     def _launch_instance(self):
         """
         Do nothing.


### PR DESCRIPTION
There's no way to get a console log from SSH based testing.