### PR TITLE
Enable uefi boot for azure instances.

### DIFF
--- a/img_proof/ipa_azure.py
+++ b/img_proof/ipa_azure.py
@@ -196,6 +196,16 @@ class AzureCloud(IpaCloud):
                 }
             }
 
+        if self.enable_uefi:
+            generation = 'V2'
+        else:
+            generation = 'V1'
+
+        storage_profile['os_disk'] = {
+            'hyper_v_generation': generation,
+            'create_option': 'FromImage'
+        }
+
         return storage_profile
 
     def _create_subnet(self, resource_group_name, subnet_id, vnet_name):

--- a/img_proof/ipa_cloud.py
+++ b/img_proof/ipa_cloud.py
@@ -172,9 +172,6 @@ class IpaCloud(object):
         self.prefix_name = self.ipa_config['prefix_name']
         self.retry_count = int(self.ipa_config['retry_count'])
 
-        if self.enable_secure_boot and not self.enable_uefi:
-            self.enable_uefi = True
-
         if self.cloud_config:
             self.cloud_config = os.path.expanduser(self.cloud_config)
 

--- a/img_proof/ipa_gce.py
+++ b/img_proof/ipa_gce.py
@@ -104,6 +104,9 @@ class GCECloud(IpaCloud):
                 'SSH private key file is required to connect to instance.'
             )
 
+        if self.enable_secure_boot and not self.enable_uefi:
+            self.enable_uefi = True
+
         self.ssh_user = self.ssh_user or GCE_DEFAULT_USER
         self.ssh_public_key = self._get_ssh_public_key()
         self.image_project = self.custom_args.get('image_project')


### PR DESCRIPTION
Move flag that auto-sets enable_uefi if enable_secure_boot is True. This only makes sense for GCE since Azure has no support for secure boot.