### PR TITLE
Catch unhandled exceptions from pytest.

### DIFF
--- a/img_proof/ipa_cloud.py
+++ b/img_proof/ipa_cloud.py
@@ -349,7 +349,7 @@ class IpaCloud(object):
         if self.early_exit:
             options.append('-x')
 
-        args = '-v {} --ssh-config={} --hosts={} {}'.format(
+        args = '-v -s {} --ssh-config={} --hosts={} {}'.format(
                 ' '.join(options),
                 ssh_config,
                 self.instance_ip,
@@ -369,7 +369,11 @@ class IpaCloud(object):
 
         while num_retries < self.retry_count:
             plugin = Report()
-            result = pytest.main(cmds, plugins=[plugin])
+
+            try:
+                result = pytest.main(cmds, plugins=[plugin])
+            except Exception:
+                result = 2
 
             if result != 0:
                 num_retries += 1

--- a/img_proof/ipa_cloud.py
+++ b/img_proof/ipa_cloud.py
@@ -373,7 +373,7 @@ class IpaCloud(object):
             try:
                 result = pytest.main(cmds, plugins=[plugin])
             except Exception:
-                result = 2
+                result = 3  # See below for pytest error codes
 
             if result != 0:
                 num_retries += 1


### PR DESCRIPTION
- And retry the given test.
- Also, disable all pytest stdout capturing with -s option. This
seems to clash with img-proof which already redirects stdout to a
log file. https://docs.pytest.org/en/stable/capture.html