### PR TITLE
- Test that multipath is dsiabled on the kernel command line

### DIFF
--- a/usr/share/lib/img_proof/tests/SLES/test_sles.yaml
+++ b/usr/share/lib/img_proof/tests/SLES/test_sles.yaml
@@ -8,3 +8,4 @@ tests:
   - test_sles_haveged
   - test_sles_lscpu
   - test_sles_kernel_version
+  - test_sles_multipath_off

--- a/usr/share/lib/img_proof/tests/SLES/test_sles_multipath_off.py
+++ b/usr/share/lib/img_proof/tests/SLES/test_sles_multipath_off.py
@@ -1,0 +1,3 @@
+def test_sles_multipath_off(host):
+    kernel_cmdline = host.file('/proc/cmdline')
+    assert kernel_cmdline.contains(' multipath=off ')


### PR DESCRIPTION
  + We have cases where multipath ends up in the initrd. This causes boot
    issues in the cloud frameworks if device mapper starts. Make sure it
    is disabled.