### PR TITLE
Fix SEV CAPABLE function

### DIFF
--- a/img_proof/ipa_gce.py
+++ b/img_proof/ipa_gce.py
@@ -345,6 +345,10 @@ class GCECloud(IpaCloud):
             guest_os_features.append({'type': 'UEFI_COMPATIBLE'})
 
         if sev_capable:
+            config['confidentialInstanceConfig'] = {
+                'enableConfidentialCompute': True
+            }
+            config['scheduling'] = {'onHostMaintenance': 'TERMINATE'}
             guest_os_features.append({'type': 'SEV_CAPABLE'})
 
         if guest_os_features:

--- a/usr/share/lib/img_proof/tests/SLES/GCE/test_sles_gce_sev.py
+++ b/usr/share/lib/img_proof/tests/SLES/GCE/test_sles_gce_sev.py
@@ -1,0 +1,4 @@
+def test_sles_gce_sev(host):
+    expected = 'AMD Secure Encrypted Virtualization (SEV) active'
+    output = host.run('dmesg | grep SEV')
+    assert expected in output.stdout.strip()

--- a/usr/share/lib/img_proof/tests/SLES/test_sles.yaml
+++ b/usr/share/lib/img_proof/tests/SLES/test_sles.yaml
@@ -8,4 +8,3 @@ tests:
   - test_sles_haveged
   - test_sles_lscpu
   - test_sles_kernel_version
-  - test_sles_multipath_off


### PR DESCRIPTION
- Add a test
- And remove multipath check from base description for now.

I went with the full string match for SEV test. If it turns out to be troublesome we can make it less explicit.