### PR TITLE
- Add test to ensure we have a dracut configuration that contains all…

### DIFF
--- a/usr/share/lib/img_proof/tests/SLES/EC2/test_sles_ec2.yaml
+++ b/usr/share/lib/img_proof/tests/SLES/EC2/test_sles_ec2.yaml
@@ -2,3 +2,4 @@ tests:
   - test_sles_ec2_services
   - test_sles_ec2_uuid
   - test_sles_ec2_network
+  - test_test_sles_dracut_conf

--- a/usr/share/lib/img_proof/tests/SLES/EC2/test_sles_ec2_dracut_conf.py
+++ b/usr/share/lib/img_proof/tests/SLES/EC2/test_sles_ec2_dracut_conf.py
@@ -1,0 +1,6 @@
+def test_sles_dracut_conf(host):
+    needed_drivers = ('ena', 'nvme', 'nvme-core', 'virtio', 'virtio_scsi',
+                      'xen-blkfront', 'xen-netfront')
+    dracut_conf = host.file('/etc/dracut.conf.d/07-aws-type-switch.conf')
+    for driver in needed_drivers:
+        assert dracut_conf.contains(driver)


### PR DESCRIPTION
… the

  drivers necessary to support instance type switching between nitro and
  xen based instances