### PR TITLE
Bump ec2 net test timeout.

### DIFF
--- a/usr/share/lib/img_proof/tests/SLES/EC2/test_sles_ec2_network.py
+++ b/usr/share/lib/img_proof/tests/SLES/EC2/test_sles_ec2_network.py
@@ -16,7 +16,7 @@ special_regions = [
     'us-gov-west-1'
 ]
 
-dl_time = 15
+dl_time = 20
 
 
 def test_sles_ec2_network(determine_region, host):


### PR DESCRIPTION
To prevent false negatives.