### PR TITLE
Split kernel command line args before compare.

### DIFF
--- a/usr/share/lib/img_proof/tests/SLES/test_sles_multipath_off.py
+++ b/usr/share/lib/img_proof/tests/SLES/test_sles_multipath_off.py
@@ -1,3 +1,4 @@
 def test_sles_multipath_off(host):
-    kernel_cmdline = host.file('/proc/cmdline')
-    assert kernel_cmdline.contains(' multipath=off ')
+    kernel_cmdline = host.run('cat /proc/cmdline')
+    args = kernel_cmdline.stdout.split()
+    assert 'multipath=off' in args


### PR DESCRIPTION
This removes descrepencies in white space due to placement of multipath arg.