### PR TITLE
- Update the GCE test to reflect the latest changes to the service

### DIFF
--- a/usr/share/lib/img_proof/tests/SLES/GCE/test_sles_gce_services.py
+++ b/usr/share/lib/img_proof/tests/SLES/GCE/test_sles_gce_services.py
@@ -2,7 +2,9 @@ import pytest
 
 
 @pytest.mark.parametrize('name', [
-    'google-guest-agent'
+    'google-guest-agent',
+    'google-osconfig-agent',
+    'google-oslogin-cache.timer'
 ])
 def test_sles_gce_running_services(check_service, name):
     assert check_service(name)
@@ -11,9 +13,6 @@ def test_sles_gce_running_services(check_service, name):
 @pytest.mark.parametrize('name', [
     'google-startup-scripts',
     'google-shutdown-scripts',
-    'google-optimize-local-ssd',
-    'google-oslogin-cache',
-    'google-set-multiqueue'
 ])
 def test_sles_gce_one_shot_services(check_service, host, name):
     assert check_service(name, running=None)


### PR DESCRIPTION
  configuration.
  + google-optimize-local-ssd.service and google-set-multiqueue.service are
    have been removed from the images
  + google-osconfig-agent.service and google-oslogin-cache.timer have been
    added to the image builds