### PR TITLE
- Make content check fro dracut config version specific

### DIFF
--- a/usr/share/lib/img_proof/tests/SLES/EC2/test_sles_ec2_dracut_conf.py
+++ b/usr/share/lib/img_proof/tests/SLES/EC2/test_sles_ec2_dracut_conf.py
@@ -1,6 +1,10 @@
 import pytest
 
-def test_sles_ec2_x86_64_dracut_conf(host):
+
+def test_sles_ec2_dracut_conf(host, get_release_value, determine_architecture):
+    if determine_architecture() != 'X86_64':
+        pytest.skip('Only x86_64 architecture is tested.')
+
     needed_drivers = (
         'ena',
         'nvme',

--- a/usr/share/lib/img_proof/tests/SLES/EC2/test_sles_ec2_x86_64_dracut_conf.py
+++ b/usr/share/lib/img_proof/tests/SLES/EC2/test_sles_ec2_x86_64_dracut_conf.py
@@ -1,3 +1,5 @@
+import pytest
+
 def test_sles_ec2_x86_64_dracut_conf(host):
     needed_drivers = (
         'ena',
@@ -8,6 +10,8 @@ def test_sles_ec2_x86_64_dracut_conf(host):
         'xen-blkfront',
         'xen-netfront'
     )
+    version = get_release_value('VERSION')
+    assert version
 
     dracut_conf = host.file('/etc/dracut.conf.d/07-aws-type-switch.conf')
 
@@ -15,4 +19,9 @@ def test_sles_ec2_x86_64_dracut_conf(host):
     assert dracut_conf.is_file
 
     for driver in needed_drivers:
+        if (
+                driver.startswith('virtio') and
+                (version.startswith('15') or version == '12-SP5')
+        ):
+            continue
         assert dracut_conf.contains(driver)


### PR DESCRIPTION
  + Only kernels prior to 12 SP5 have a virtio module. Further with the
    12 SP5 and later kernels virtio modules of any kind are no longer
    needed in the initrd for instance type portability.