### PR TITLE
Add case to handle sapcal in repos test.

### DIFF
--- a/usr/share/lib/img_proof/tests/SLES/test_sles_repos.py
+++ b/usr/share/lib/img_proof/tests/SLES/test_sles_repos.py
@@ -6,7 +6,8 @@ def test_sles_repos(
     get_release_value,
     get_sles_repos,
     get_baseproduct,
-    determine_architecture
+    determine_architecture,
+    is_sles_sapcal
 ):
     version = [get_release_value('VERSION'), determine_architecture()]
 
@@ -20,6 +21,12 @@ def test_sles_repos(
 
     missing_repos = []
     repos = get_sles_repos(version)
+
+    if is_sles_sapcal():
+        repos = [repo for repo in repos if 'Python2' not in repo]
+
+        if get_release_value('VERSION') == '12-SP3':
+            repos = [repo for repo in repos if 'HPC' not in repo]
 
     if not repos:
         pytest.fail(

--- a/usr/share/lib/img_proof/tests/conftest.py
+++ b/usr/share/lib/img_proof/tests/conftest.py
@@ -133,6 +133,14 @@ def is_sles_sap(host, get_baseproduct):
 
 
 @pytest.fixture()
+def is_sles_sapcal(host):
+    def f():
+        motd = host.file('/etc/motd')
+        return motd.contains('SAPCAL')
+    return f
+
+
+@pytest.fixture()
 def get_release_value(host):
     def f(key):
         release = host.file('/etc/os-release')


### PR DESCRIPTION
Skip python2 modules which are not in sapcal images.

This is a temp fix until the repos test can be re-worked to test modules rather than repos.