### PR TITLE
Make the SEV check more lenient

### DIFF
--- a/usr/share/lib/img_proof/tests/SLES/GCE/test_sles_gce_sev.py
+++ b/usr/share/lib/img_proof/tests/SLES/GCE/test_sles_gce_sev.py
@@ -1,4 +1,4 @@
 def test_sles_gce_sev(host):
-    expected = 'AMD Secure Encrypted Virtualization (SEV) active'
-    output = host.run('dmesg | grep SEV')
+    expected = 'SEV'
+    output = host.run('dmesg')
     assert expected in output.stdout.strip()


### PR DESCRIPTION
Since the wording changes between service packs. `SEV` will only
show up in dmesg when SEV is enabled.