### PR TITLE
Fix name check when cleanup up network components

### DIFF
--- a/img_proof/ipa_oci.py
+++ b/img_proof/ipa_oci.py
@@ -503,7 +503,7 @@ class OCICloud(IpaCloud):
             ]
         )
 
-        if not self.display_name.startswith('oci-ipa-test'):
+        if 'img-proof' not in self.display_name:
             # Only cleanup artifacts created by img-proof
             return
 


### PR DESCRIPTION
Cleanup if "img-proof" in name.