### PR TITLE
Fix gce ssh key insertion

### DIFF
--- a/img_proof/ipa_gce.py
+++ b/img_proof/ipa_gce.py
@@ -171,9 +171,9 @@ class GCECloud(IpaCloud):
     def _get_ssh_public_key(self):
         """Generate SSH public key from private key."""
         key = ipa_utils.get_public_ssh_key(self.ssh_private_key_file)
-        return '{user}:{key} {user}'.format(
+        return '{user}:{key}'.format(
             user=self.ssh_user,
-            key=key.decode()
+            key=key.decode().strip()
         )
 
     def _get_network(self, network_id):


### PR DESCRIPTION
The public key in openssh format will already have a user name or
email appended. This prevents gce from creating a second broken
key entry.