### PR TITLE
Import strtobool function locally

### DIFF
--- a/img_proof/ipa_cloud.py
+++ b/img_proof/ipa_cloud.py
@@ -30,7 +30,6 @@ import pytest
 
 from collections import ChainMap, defaultdict
 from datetime import datetime
-from distutils.util import strtobool
 
 from img_proof import ipa_utils
 from img_proof.ipa_constants import (
@@ -169,7 +168,7 @@ class IpaCloud(object):
         self.enable_secure_boot = self.ipa_config['enable_secure_boot']
         self.enable_uefi = self.ipa_config['enable_uefi']
         self.no_default_test_dirs = bool(
-            strtobool(str(self.ipa_config['no_default_test_dirs']))
+            ipa_utils.strtobool(str(self.ipa_config['no_default_test_dirs']))
         )
         self.prefix_name = self.ipa_config['prefix_name']
         self.retry_count = int(self.ipa_config['retry_count'])

--- a/img_proof/ipa_utils.py
+++ b/img_proof/ipa_utils.py
@@ -578,3 +578,18 @@ def load_json(file_path):
         data = json.load(json_file)
 
     return data
+
+
+def strtobool(val: str) -> int:
+    """
+    This function implements a strtobool to replace distutils requirement
+
+    Distutils module is deprecated:
+    https://www.python.org/dev/peps/pep-0632/ for details.
+    """
+    val = val.lower()
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        return 1
+    if val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return 0
+    raise ValueError(f"Invalid truth value {val}")


### PR DESCRIPTION
Since distutils is deprecated importing from distutils can cause
problems depending on the python implementation in use.