### PR TITLE
Handle the API change in cloud-regionsrv-client

### DIFF
--- a/usr/share/lib/img_proof/tests/conftest.py
+++ b/usr/share/lib/img_proof/tests/conftest.py
@@ -25,7 +25,7 @@ def check_cloud_register(host):
             "{0}))'".format(is_registered_arg)
         )
         output = result.stdout.strip()
-        return output == '1'
+        return output in ('1', 'True')
     return f
 
 

--- a/usr/share/lib/img_proof/tests/conftest.py
+++ b/usr/share/lib/img_proof/tests/conftest.py
@@ -7,10 +7,22 @@ from susepubliccloudinfoclient import infoserverrequests
 @pytest.fixture()
 def check_cloud_register(host):
     def f():
+        # There was an API change in registerutils and we have to check
+        # which version is in place on the system
+        deleted_interface_import = \
+            'from cloudregister.registerutils import check_registration'
+        result = host.run(
+            "sudo python3 -c '{0}'".format(deleted_interface_import)
+        )
+        # Old interface of is_registered()
+        is_registered_arg = 'registerutils.get_current_smt()'
+        if result.stdout.strip() == '1':
+            # New interface of is_registered()
+            is_registered_arg = 'registerutils.get_current_smt().get_FQDN()'
         result = host.run(
             "sudo python3 -c 'from cloudregister import registerutils; "
             "print(registerutils.is_registered("
-            "registerutils.get_current_smt()))'"
+            "{0}))'".format(is_registered_arg)
         )
         output = result.stdout.strip()
         return output == '1'

--- a/usr/share/lib/img_proof/tests/conftest.py
+++ b/usr/share/lib/img_proof/tests/conftest.py
@@ -16,7 +16,7 @@ def check_cloud_register(host):
         )
         # Old interface of is_registered()
         is_registered_arg = 'registerutils.get_current_smt()'
-        if result.stdout.strip() == '1':
+        if result.rc == 1:
             # New interface of is_registered()
             is_registered_arg = 'registerutils.get_current_smt().get_FQDN()'
         result = host.run(


### PR DESCRIPTION
- The cloud-regionsrv-client API for the is_registered() function has
  changed from expecting an object to expecting a string. Change the
  test implementation to handle both cases.