### PR TITLE
Fix test for aarch64 Azure kernel commandline args

### DIFF
--- a/usr/share/lib/img_proof/tests/SLES/Azure/test_sles_azure_kernel_cmdline.py
+++ b/usr/share/lib/img_proof/tests/SLES/Azure/test_sles_azure_kernel_cmdline.py
@@ -11,7 +11,7 @@ def test_sles_azure_kernel_cmdline(host, determine_architecture):
         'AARCH64': [
             'console=tty1',
             'console=ttyAMA0',
-            'earlycon=pl011,0xeffeb000',
+            'earlycon=pl011,0xeffec000',
             'initcall_blacklist=arm_pmu_acpi_init'
         ]
     }


### PR DESCRIPTION
When the test was implemented the initial vallue was incorrect. Fix the test to reflect the values used in production and confirmed with the Azure team.