### PR TITLE
Use full path to dmidecode

### DIFF
--- a/usr/share/lib/img_proof/tests/conftest.py
+++ b/usr/share/lib/img_proof/tests/conftest.py
@@ -76,7 +76,7 @@ def determine_architecture(host):
 @pytest.fixture()
 def determine_provider(host):
     def f():
-        result = host.run('sudo dmidecode -t system')
+        result = host.run('sudo /usr/sbin/dmidecode -t system')
         output = result.stdout.lower()
         if 'amazon' in output:
             provider = 'ec2'


### PR DESCRIPTION
Which is no longer in path by default