### PR TITLE
The tty for aarch64 in 15-SP5 is no longer tty1

### DIFF
--- a/usr/share/lib/img_proof/tests/SLES/Azure/test_sles_azure_kernel_cmdline.py
+++ b/usr/share/lib/img_proof/tests/SLES/Azure/test_sles_azure_kernel_cmdline.py
@@ -9,7 +9,6 @@ def test_sles_azure_kernel_cmdline(host, determine_architecture):
             'earlyprintk=ttyS0'
         ],
         'AARCH64': [
-            'console=tty1',
             'console=ttyAMA0',
             'earlycon=pl011,0xeffec000',
             'initcall_blacklist=arm_pmu_acpi_init'


### PR DESCRIPTION
Related ticket: https://progress.opensuse.org/issues/126002
Failing test: https://openqa.suse.de/tests/10835083

Solves the issue with:
`E           AssertionError: assert 'console=tty1' in ['BOOT_IMAGE=/Image-5.14.21-150500.46-default', 'root=UUID=41a60a97-0d45-480b-bd09-63aba9d14659', 'console=ttyS0', 'net.ifnames=0', 'dis_ucode_ldr', 'earlyprintk=ttyS0', ...]`