### PR TITLE
Remove the Legacy module from the repo test

### DIFF
--- a/usr/share/lib/img_proof/tests/SLES/conftest.py
+++ b/usr/share/lib/img_proof/tests/SLES/conftest.py
@@ -500,15 +500,15 @@ SLE_15_SP3_X86_64_MODULES = [
 
 BASE_15_SP4 = [
     repo.replace('SP3', 'SP4') for repo in BASE_15_SP3
-    if 'Python2' not in repo
+    if ('Python2' not in repo and 'Legacy' not in repo)
 ]
 BASE_15_SP4_SAP = [
     repo.replace('SP3', 'SP4') for repo in BASE_15_SP3_SAP
-    if 'Python2' not in repo
+    if ('Python2' not in repo and 'Legacy' not in repo)
 ]
 BASE_15_SP4_HPC = [
     repo.replace('SP3', 'SP4') for repo in BASE_15_SP3_HPC
-    if 'Python2' not in repo
+    if ('Python2' not in repo and 'Legacy' not in repo)
 ]
 SLE_15_SP4_X86_64_MODULES = [
     repo.replace('SP3', 'SP4') for repo in SLE_15_SP3_X86_64_MODULES


### PR DESCRIPTION
Starting with 15 SP4 the Legacy module is no longer included in our images.