### PR TITLE
Includes a CLI parameter to include cpu-options in AWS instances

### DIFF
--- a/img_proof/ipa_controller.py
+++ b/img_proof/ipa_controller.py
@@ -95,7 +95,8 @@ def test_image(
     image_version=None,
     architecture=None,
     beta=None,
-    exclude=None
+    exclude=None,
+    cpu_options=None
 ):
     """Creates a cloud framework instance and initiates testing."""
     kwargs = {
@@ -150,7 +151,8 @@ def test_image(
             'secret_access_key': secret_access_key,
             'security_group_id': security_group_id,
             'ssh_key_name': ssh_key_name,
-            'additional_info': additional_info
+            'additional_info': additional_info,
+            'cpu_options': cpu_options
         }
         cloud = EC2Cloud(**kwargs)
     elif cloud_name == 'gce':

--- a/img_proof/ipa_ec2.py
+++ b/img_proof/ipa_ec2.py
@@ -232,6 +232,12 @@ class EC2Cloud(IpaCloud):
         if self.additional_info:
             kwargs['AdditionalInfo'] = self.additional_info
 
+        cpu_options = self.custom_args.get('cpu_options', [])
+        if cpu_options:
+            kwargs['CpuOptions'] = {}
+            for cpu_op in cpu_options:
+                kwargs['CpuOption'][cpu_op.get('key')] = cpu_op.get('value')
+
         try:
             instances = resource.create_instances(**kwargs)
         except Exception as error:

--- a/img_proof/ipa_ec2.py
+++ b/img_proof/ipa_ec2.py
@@ -232,11 +232,9 @@ class EC2Cloud(IpaCloud):
         if self.additional_info:
             kwargs['AdditionalInfo'] = self.additional_info
 
-        cpu_options = self.custom_args.get('cpu_options', [])
+        cpu_options = self.custom_args.get('cpu_options', {})
         if cpu_options:
-            kwargs['CpuOptions'] = {}
-            for cpu_op in cpu_options:
-                kwargs['CpuOption'][cpu_op.get('key')] = cpu_op.get('value')
+            kwargs['CpuOptions'] = cpu_options
 
         try:
             instances = resource.create_instances(**kwargs)

--- a/img_proof/scripts/cli.py
+++ b/img_proof/scripts/cli.py
@@ -39,6 +39,7 @@ from img_proof.ipa_constants import TEST_PATHS
 from img_proof.ipa_controller import collect_tests, test_image
 from img_proof.scripts.cli_utils import (
     archive_history_item,
+    cli_process_cpu_options,
     echo_log,
     echo_results,
     echo_results_file,
@@ -116,6 +117,16 @@ def main(context, no_color):
     '--config',
     type=click.Path(exists=True),
     help='img_proof config file location. Default: ~/.config/img_proof/config'
+)
+@click.option(
+    '--cpu-options',
+    callback=cli_process_cpu_options,
+    default='',
+    help=(
+        'CPU options to be activated when launching instances for tests.'
+        'Example: --cpu-option AmdSevSnp=enabled'
+        'Multiple values can be specified separated by comma.'
+    )
 )
 @click.option(
     '-D',
@@ -384,6 +395,7 @@ def test(context,
          account,
          cleanup,
          config,
+         cpu_options,
          description,
          distro,
          early_exit,
@@ -497,7 +509,8 @@ def test(context,
             image_version,
             architecture,
             beta,
-            exclude
+            exclude,
+            cpu_options
         )
         echo_results(results, no_color)
         sys.exit(status)

--- a/img_proof/scripts/cli_utils.py
+++ b/img_proof/scripts/cli_utils.py
@@ -73,6 +73,24 @@ def archive_history_item(item, destination, no_color):
         )
 
 
+def cli_process_cpu_options(cxt, param, value):
+    cpu_options = []
+    if value:
+        try:
+            for cpu_option in value.split(','):
+                key, val = cpu_option.split('=', 1)
+                option = {
+                    'key': key,
+                    'value': val
+                }
+                cpu_options.append(option)
+        except Exception as e:
+            raise click.BadParameter(
+                "Issue with cpu-option parameter: %s" % e
+            )
+    return cpu_options
+
+
 def echo_log(log_file, no_color):
     try:
         with open(log_file, 'r') as f:

--- a/img_proof/scripts/cli_utils.py
+++ b/img_proof/scripts/cli_utils.py
@@ -74,19 +74,16 @@ def archive_history_item(item, destination, no_color):
 
 
 def cli_process_cpu_options(cxt, param, value):
-    cpu_options = []
+    cpu_options = {}
     if value:
         try:
-            for cpu_option in value.split(','):
-                key, val = cpu_option.split('=', 1)
-                option = {
-                    'key': key,
-                    'value': val
-                }
-                cpu_options.append(option)
+            cpu_options.update(
+                dict(option.split('=', 1) for option in value.split(","))
+            )
         except Exception as e:
             raise click.BadParameter(
-                "Issue with cpu-option parameter: %s" % e
+                "--cpu-options parameter is invalid: %s" % e +
+                '. (example value: "--cpu-options AmdSevSnp=enabled")'
             )
     return cpu_options
 

--- a/tests/test_ipa_cli_utils.py
+++ b/tests/test_ipa_cli_utils.py
@@ -63,13 +63,19 @@ def test_cli_process_cpu_options():
         {
             'input': 'AmdSevSnp=enabled',
             'expected_output': {
-                'key': 'AmdSevSnp',
-                'value': 'enabled'
+                'AmdSevSnp': 'enabled'
             }
         },
         {
             'input': 'ExceptionShouldBeRaised'
-        }
+        },
+        {
+            'input': 'AmdSevSnp=enabled,secondOption=secondValue',
+            'expected_output': {
+                'AmdSevSnp': 'enabled',
+                'secondOption': 'secondValue'
+            }
+        },
     ]
 
     for data in TEST_DATA:
@@ -80,7 +86,7 @@ def test_cli_process_cpu_options():
                 data['input']
             )
 
-            assert data['expected_output'] == output[0]
+            assert data['expected_output'] == output
         else:
             with pytest.raises(BadParameter) as exc:
                 cli_utils.cli_process_cpu_options(

--- a/tests/test_ipa_cli_utils.py
+++ b/tests/test_ipa_cli_utils.py
@@ -21,7 +21,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import pytest
+
 from img_proof.scripts import cli_utils
+from click import BadParameter
 
 DATA = {
     "info": {
@@ -52,3 +55,37 @@ DATA = {
 def test_echo_results():
     """Test cli utils echo results."""
     cli_utils.echo_results(DATA, False, verbose=True)
+
+
+def test_cli_process_cpu_options():
+    """Test process-cpu options"""
+    TEST_DATA = [
+        {
+            'input': 'AmdSevSnp=enabled',
+            'expected_output': {
+                'key': 'AmdSevSnp',
+                'value': 'enabled'
+            }
+        },
+        {
+            'input': 'ExceptionShouldBeRaised'
+        }
+    ]
+
+    for data in TEST_DATA:
+        if 'expected_output' in data:
+            output = cli_utils.cli_process_cpu_options(
+                {},
+                'cpu-options',
+                data['input']
+            )
+
+            assert data['expected_output'] == output[0]
+        else:
+            with pytest.raises(BadParameter) as exc:
+                cli_utils.cli_process_cpu_options(
+                    {},
+                    'cpu-options',
+                    data['input']
+                )
+                assert str(exc).contains(data['input'])

--- a/tox.ini
+++ b/tox.ini
@@ -3,11 +3,12 @@ envlist =
     py35
     py36
     py37
+    py38
 
 [testenv]
 passenv = HOME
 commands =
     pip install -e .[dev]
     pytest --cov=img_proof
-    flake8 img-proof
+    flake8 img_proof
     flake8 tests --exclude=data


### PR DESCRIPTION
To address [Issue 363](https://github.com/SUSE-Enceladus/img-proof/issues/363).

Includes a new CLI option (`--cpu-options AmdSevSnp=enabled`) to allow enabling SEV-SNP feature in EC2 instances.

The mechanism is generic and allows to include, if required, additional cpu-options without code changes.

I did NOT test the feature with an instance...