### PR TITLE
Show command stdout/err when setup_swap() fails

### DIFF
--- a/usr/share/lib/img_proof/tests/SLES/test_sles_hardened.py
+++ b/usr/share/lib/img_proof/tests/SLES/test_sles_hardened.py
@@ -23,6 +23,9 @@ def setup_swap(host, swap_file=SWAP_FILE):
         ]:
             result = host.run(command)
             if result.rc != 0:
+                print("{} command failed".format(command))
+                print("STDOUT: {}".format(result.stdout.strip()))
+                print("STDERR: {}".format(result.stderr.strip()))
                 return False
     return True
 


### PR DESCRIPTION
Show command output to help debugging issue with setup_swap()

Verification run: https://openqa.suse.de/tests/13310302/logfile?filename=serial_terminal.txt

We're having issue: `STDERR: truncate: failed to truncate '/swap' at 0 bytes: Text file busy`
