### PR TITLE
Enhance hardened_test debugging

### DIFF
--- a/usr/share/lib/img_proof/tests/SLES/test_sles_hardened.py
+++ b/usr/share/lib/img_proof/tests/SLES/test_sles_hardened.py
@@ -66,8 +66,9 @@ def test_sles_hardened(host, get_release_value, is_sles_sap, is_sle_micro):
     scap_report = os.environ.get("SCAP_REPORT", "")
     if scap_report:
         if os.path.exists(scap_report) or not scap_report.endswith(".html"):
-            pytest.skip("Invalid filename for SCAP_REPORT: {}".format(scap_report))
-        scap_report = "--report {}".format(scap_report)
+            print("Ignoring SCAP_REPORT: {}".format(scap_report))
+        else:
+            scap_report = "--report {}".format(scap_report)
 
     result = host.run(
         "sudo oscap xccdf eval {scap_report} --local-files {dir} --profile {profile} {file}".format(

--- a/usr/share/lib/img_proof/tests/SLES/test_sles_hardened.py
+++ b/usr/share/lib/img_proof/tests/SLES/test_sles_hardened.py
@@ -63,7 +63,7 @@ def test_sles_hardened(host, get_release_value, is_sles_sap, is_sle_micro):
     )
 
     result = host.run(
-        "sudo oscap xccdf eval --local-files {dir} --profile {profile} {file}".format(
+        "sudo oscap xccdf eval --report /var/tmp/report.html --local-files {dir} --profile {profile} {file}".format(
             dir=oscap_dir,
             file=oscap_file,
             profile=oscap_profile,

--- a/usr/share/lib/img_proof/tests/SLES/test_sles_hardened.py
+++ b/usr/share/lib/img_proof/tests/SLES/test_sles_hardened.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 
@@ -62,8 +63,15 @@ def test_sles_hardened(host, get_release_value, is_sles_sap, is_sle_micro):
         )
     )
 
+    scap_report = os.environ.get("SCAP_REPORT", "")
+    if scap_report:
+        if os.path.exists(scap_report) or not scap_report.endswith(".html"):
+            pytest.skip("Invalid filename for SCAP_REPORT: {}".format(scap_report))
+        scap_report = "--report {}".format(scap_report)
+
     result = host.run(
-        "sudo oscap xccdf eval --report /var/tmp/report.html --local-files {dir} --profile {profile} {file}".format(
+        "sudo oscap xccdf eval {scap_report} --local-files {dir} --profile {profile} {file}".format(
+            scap_report=scap_report,
             dir=oscap_dir,
             file=oscap_file,
             profile=oscap_profile,

--- a/usr/share/lib/img_proof/tests/SLES/test_sles_hardened.py
+++ b/usr/share/lib/img_proof/tests/SLES/test_sles_hardened.py
@@ -23,7 +23,7 @@ def setup_swap(host, swap_file=SWAP_FILE):
         ]:
             result = host.run(command)
             if result.rc != 0:
-                print("{} command failed".format(command))
+                print("{} command failed with {}".format(command, result.rc))
                 print("STDOUT: {}".format(result.stdout.strip()))
                 print("STDERR: {}".format(result.stderr.strip()))
                 return False
@@ -69,6 +69,11 @@ def test_sles_hardened(host, get_release_value, is_sles_sap, is_sle_micro):
             profile=oscap_profile,
         )
     )
+
+    if result.rc != 0:
+        print("oscap command failed with {}".format(result.rc))
+        print("STDOUT: {}".format(result.stdout.strip()))
+        print("STDERR: {}".format(result.stderr.strip()))
 
     assert result.rc == 0
 


### PR DESCRIPTION
This PR:
- Adds a HTML report to be consumed by openQA.
- Prints stdout/stderr of oscap when command fails.

