### PR TITLE
Add instance options cli option

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -28,6 +28,48 @@ As seen in the example the CLI output verbosity can be controlled via options:
 **\-\-quiet**
     Silence logging information on test run.
 
+
+Instance Options
+~~~~~~~~~~~~~~~~
+
+The **instance-option** arguments provide a way to enable instance options
+that will be activated when launching instances. This is a multi-option
+value. To provide multiple options in a single command split each option
+into a separate argement. An example for tests in Google:
+
+.. code-block:: console
+
+   img-proof test gcp ... \
+     --instance-option SEV_SNP_CAPABLE \
+     --instance-option GVNIC
+
+The Google instance options are the guest os feature flags. See
+https://cloud.google.com/compute/docs/images/create-custom#guest-os-features
+for more details. As seen above a an example for Google looks like:
+
+.. code-block:: console
+
+   img-proof test gcp ... \
+     --instance-option SEV_SNP_CAPABLE
+
+The Amazon options are the different options available when running the
+run instances command. These can be found at
+https://docs.aws.amazon.com/cli/latest/reference/ec2/run-instances.html.
+
+To provide an instance option for testing in Amazon the type of option
+and the key/val are provided in the following format: "OptType=key.val".
+Example usage to enable SEV SNP looks like:
+
+.. code-block:: console
+
+   img-proof test ec2 ... \
+     --instance-option CpuOptions=AmdSevSnp.enabled
+
+
+Where the key is derived from the CLI reference page provided above. In
+this case the AWS CLI option is --cpu-options which becomes "CpuOptions".
+"AmdSevSnp" is the key and the value is "enabled".
+
 Cleanup
 ~~~~~~~
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -35,7 +35,7 @@ Instance Options
 The **instance-option** arguments provide a way to enable instance options
 that will be activated when launching instances. This is a multi-option
 value. To provide multiple options in a single command split each option
-into a separate argement. An example for tests in Google:
+into a separate argument. An example for tests in Google:
 
 .. code-block:: console
 
@@ -45,7 +45,7 @@ into a separate argement. An example for tests in Google:
 
 The Google instance options are the guest os feature flags. See
 https://cloud.google.com/compute/docs/images/create-custom#guest-os-features
-for more details. As seen above a an example for Google looks like:
+for more details. As seen above an example for Google looks like:
 
 .. code-block:: console
 

--- a/img_proof/ipa_cloud.py
+++ b/img_proof/ipa_cloud.py
@@ -108,6 +108,7 @@ class IpaCloud(object):
         root_disk_size=None,
         beta=None,
         exclude=None,
+        instance_options=None,
         custom_args=None
     ):
         """Initialize base cloud framework class."""
@@ -178,6 +179,7 @@ class IpaCloud(object):
         self.root_disk_size = int(self.ipa_config['root_disk_size'])
         self.beta = self.ipa_config['beta']
         self.exclude = exclude or []
+        self.instance_options = instance_options or []
 
         if self.enable_secure_boot and not self.enable_uefi:
             self.enable_uefi = True

--- a/img_proof/ipa_controller.py
+++ b/img_proof/ipa_controller.py
@@ -96,7 +96,8 @@ def test_image(
     architecture=None,
     beta=None,
     exclude=None,
-    cpu_options=None
+    cpu_options=None,
+    instance_options=None
 ):
     """Creates a cloud framework instance and initiates testing."""
     kwargs = {
@@ -129,7 +130,8 @@ def test_image(
         'retry_count': retry_count,
         'root_disk_size': root_disk_size,
         'beta': beta,
-        'exclude': exclude
+        'exclude': exclude,
+        'instance_options': instance_options
     }
 
     cloud_name = cloud_name.lower()

--- a/img_proof/ipa_ec2.py
+++ b/img_proof/ipa_ec2.py
@@ -233,6 +233,14 @@ class EC2Cloud(IpaCloud):
             kwargs['AdditionalInfo'] = self.additional_info
 
         cpu_options = self.custom_args.get('cpu_options', {})
+        for option in self.instance_options:
+            try:
+                key, value = option.split('=')
+            except ValueError:
+                self.logger.warning(f'Invalid CPU option provided: {option}')
+
+            cpu_options[key] = value
+
         if cpu_options:
             kwargs['CpuOptions'] = cpu_options
 

--- a/img_proof/ipa_ec2.py
+++ b/img_proof/ipa_ec2.py
@@ -235,11 +235,23 @@ class EC2Cloud(IpaCloud):
         cpu_options = self.custom_args.get('cpu_options', {})
         for option in self.instance_options:
             try:
+                # AmdSevSnp=enabled
                 key, value = option.split('=')
             except ValueError:
                 self.logger.warning(f'Invalid CPU option provided: {option}')
 
-            cpu_options[key] = value
+            try:
+                # CpuOptions=AmdSevSnp.enabled
+                opt_key, opt_val = value.split('.')
+            except ValueError:
+                opt_key = None
+
+            if opt_key and key.lower() == 'cpuoptions':
+                cpu_options[opt_key] = opt_val
+            elif opt_key and key.lower() != 'cpuoptions':
+                pass  # No other options supported at the moment
+            else:
+                cpu_options[key] = value
 
         if cpu_options:
             kwargs['CpuOptions'] = cpu_options

--- a/img_proof/scripts/cli.py
+++ b/img_proof/scripts/cli.py
@@ -134,13 +134,13 @@ def main(context, no_color):
     multiple=True,
     help=(
         'Instance options to be activated when launching instances for tests. '
-        'Amazon Example: "--instance-option AmdSevSnp=enabled". '
+        'Amazon Example: "--instance-option CpuOptions=AmdSevSnp.enabled". '
         'Google Example: "--instance-option SEV_SNP_CAPABLE". '
         'Multiple values can be specified such as (Google) '
         '"--instance-option SEV_SNP_CAPABLE --instance-option GVNIC". '
-        'The Google instance options are the guest os feature flags. See '
-        'https://cloud.google.com/compute/docs/images/create-custom'
-        '#guest-os-features for more details.'
+        'More details can be found in the img-proof documentation '
+        'https://img-proof.readthedocs.io/en/latest/usage.html'
+        '#instance-options.'
     )
 )
 @click.option(

--- a/img_proof/scripts/cli.py
+++ b/img_proof/scripts/cli.py
@@ -129,6 +129,21 @@ def main(context, no_color):
     )
 )
 @click.option(
+    '--instance-option',
+    'instance_options',
+    multiple=True,
+    help=(
+        'Instance options to be activated when launching instances for tests. '
+        'Amazon Example: "--instance-option AmdSevSnp=enabled". '
+        'Google Example: "--instance-option SEV_SNP_CAPABLE". '
+        'Multiple values can be specified such as (Google) '
+        '"--instance-option SEV_SNP_CAPABLE --instance-option GVNIC". '
+        'The Google instance options are the guest os feature flags. See '
+        'https://cloud.google.com/compute/docs/images/create-custom'
+        '#guest-os-features for more details.'
+    )
+)
+@click.option(
     '-D',
     '--description',
     help='Short description for test run.'
@@ -396,6 +411,7 @@ def test(context,
          cleanup,
          config,
          cpu_options,
+         instance_options,
          description,
          distro,
          early_exit,
@@ -449,6 +465,33 @@ def test(context,
     """Test image in the given framework using the supplied test files."""
     no_color = context.obj['no_color']
     logger = ipa_utils.get_logger(log_level)
+
+    if cpu_options:
+        echo_style(
+            '--cpu-options is deprecated and replaced by '
+            '"--instance-option AmdSevSnp=enabled". '
+            '--cpu-options will be removed in v8.0.0.',
+            no_color,
+            fg='red'
+        )
+
+    if sev_capable:
+        echo_style(
+            '--sev-capable is deprecated and replaced by'
+            '"--instance-option SEV_CAPABLE". '
+            '--sev-capable will be removed in v8.0.0.',
+            no_color,
+            fg='red'
+        )
+
+    if use_gvnic:
+        echo_style(
+            '--use-gvnic is deprecated and replaced by'
+            '"--instance-option GVNIC". '
+            '--use-gvnic will be removed in v8.0.0.',
+            no_color,
+            fg='red'
+        )
 
     try:
         status, results = test_image(
@@ -510,7 +553,8 @@ def test(context,
             architecture,
             beta,
             exclude,
-            cpu_options
+            cpu_options,
+            instance_options
         )
         echo_results(results, no_color)
         sys.exit(status)

--- a/tests/test_ipa_ec2.py
+++ b/tests/test_ipa_ec2.py
@@ -44,8 +44,10 @@ class TestEC2Provider(object):
             'test_files': ['test_image'],
             'custom_args': {
                 'account_name': 'bob',
-                'ssh_key_name': 'test-key'
-            }
+                'ssh_key_name': 'test-key',
+                'cpu_options': {'AmdSevSnp': 'enabled'}
+            },
+            'instance_options': ['CpuOptions=AmdSevSnp.enabled']
         }
 
     def test_ec2_exception_required_args(self):

--- a/tests/test_ipa_gce.py
+++ b/tests/test_ipa_gce.py
@@ -315,7 +315,8 @@ class TestGCECloud(object):
             50,
             'x86_64',
             shielded_instance_config={'shielded': 'config'},
-            sev_capable=True
+            sev='SEV_SNP',
+            use_gvnic=True
         )
 
         assert 'metadata' in config

--- a/usr/share/lib/img_proof/tests/SLES/GCE/test_sles_gce_sev_snp.py
+++ b/usr/share/lib/img_proof/tests/SLES/GCE/test_sles_gce_sev_snp.py
@@ -1,0 +1,7 @@
+def test_sles_gce_sev_snp(host):
+    expected = 'SEV-SNP'
+
+    with host.sudo():
+        output = host.run('dmesg')
+
+    assert expected in output.stdout.strip()


### PR DESCRIPTION
This will be a generic way to set instance options for all csp's. Also, add sev-snp support for Google testing and a related test to confirm sev-snp is running.