### PR TITLE
Do not retry hardened test if report was already generated

### DIFF
--- a/usr/share/lib/img_proof/tests/SLES/test_sles_hardened.py
+++ b/usr/share/lib/img_proof/tests/SLES/test_sles_hardened.py
@@ -8,7 +8,7 @@ SWAP_FILE = "/swap"
 # Workaround for OOM killer triggered by the issue
 # https://github.com/OpenSCAP/openscap/issues/1796
 def setup_swap(host, swap_file=SWAP_FILE):
-    if os.path.exists(swap_file):
+    if host.file(swap_file).exists:
         return True
     # Follow steps in https://btrfs.readthedocs.io/en/latest/Swapfile.html
     for command in [
@@ -62,7 +62,7 @@ def test_sles_hardened(host, get_release_value, is_sles_sap, is_sle_micro):
 
     scap_report = os.environ.get("SCAP_REPORT", "")
     if scap_report:
-        if os.path.exists(scap_report) or not scap_report.endswith(".html"):
+        if not scap_report.endswith(".html"):
             print("Ignoring SCAP_REPORT: {}".format(scap_report))
         else:
             scap_report = "--report {}".format(scap_report)

--- a/usr/share/lib/img_proof/tests/SLES/test_sles_hardened.py
+++ b/usr/share/lib/img_proof/tests/SLES/test_sles_hardened.py
@@ -41,6 +41,16 @@ def test_sles_hardened(host, get_release_value, is_sles_sap, is_sle_micro):
     if is_sle_micro():
         pytest.skip('Skipping SLE Micro')
 
+    scap_report = os.environ.get("SCAP_REPORT", "")
+    if scap_report:
+        if not scap_report.endswith(".html"):
+            print("Ignoring SCAP_REPORT: {}".format(scap_report))
+        elif host.file(scap_report).exists:
+            # Do not retry this expensive test if a report already exists
+            pytest.fail(reason="{} exists".format(scap_report), pytrace=False)
+        else:
+            scap_report = "--report {}".format(scap_report)
+
     if not setup_swap(host):
         pytest.skip("Failed to setup swap, not enough memory.")
 
@@ -59,13 +69,6 @@ def test_sles_hardened(host, get_release_value, is_sles_sap, is_sle_micro):
             dir=oscap_dir,
         )
     )
-
-    scap_report = os.environ.get("SCAP_REPORT", "")
-    if scap_report:
-        if not scap_report.endswith(".html"):
-            print("Ignoring SCAP_REPORT: {}".format(scap_report))
-        else:
-            scap_report = "--report {}".format(scap_report)
 
     result = host.run(
         "sudo oscap xccdf eval {scap_report} --local-files {dir} --profile {profile} {file}".format(


### PR DESCRIPTION
This PR:
- Fixes swap path check to test on SUT instead of the host running the test.
- Avoid retrying hardened test if a SCAP report was generated.

Rationale:
We're using expensive VM's to run this particular test due to the workaround for OOM and these retries are burning money.

Related ticket: https://progress.opensuse.org/issues/158613
Verification run: https://openqa.suse.de/tests/13965566

The time for the VR to run was 22m12s instead of 38m42s in the [original job](https://openqa.suse.de/tests/13919363). A 42,6% reduction.