### PR TITLE
Do not search for ssh keys

### DIFF
--- a/img_proof/ipa_utils.py
+++ b/img_proof/ipa_utils.py
@@ -87,7 +87,9 @@ def establish_ssh_connection(ip,
                 port=port,
                 username=ssh_user,
                 key_filename=ssh_private_key_file,
-                timeout=timeout
+                timeout=timeout,
+                allow_agent=False,
+                look_for_keys=False
             )
         except FileNotFoundError:
             raise


### PR DESCRIPTION
If the key provided fails to establish ssh connection do not search for keys in ssh agent or ~/.ssh directory. This prevents confusing errors.