### PR TITLE
Grow root check on Terabyte drives

### DIFF
--- a/usr/share/lib/img_proof/tests/SLES/test_sles_grow_root.py
+++ b/usr/share/lib/img_proof/tests/SLES/test_sles_grow_root.py
@@ -26,15 +26,20 @@ def test_sles_grow_root(host):
         'lsblk -ndo size {device}'.format(device=device_name)
     ).stdout.strip()
 
-    disk_size = int(result.replace('G', ''))
+    try:
+        disk_size = float(result.replace('G', ''))
+        unit = 'G'
+    except ValueError:
+        disk_size = float(result.replace('T', ''))
+        unit = 'T'
 
     # Get root partition size
     result = host.run(
-        'df -BG {part} | sed 1D'.format(part=root_part)
+        'df -B{unit} {part} | sed 1D'.format(unit=unit, part=root_part)
     ).stdout.strip()
 
     root_size = shlex.split(result)[1]  # Filesystem 1G-blocks
-    root_size = int(root_size.replace('G', ''))
+    root_size = float(root_size.replace(unit, ''))
 
     # Get boot partition size
     boot_part = host.run('findmnt -v -n -f -o SOURCE /boot').stdout.strip()
@@ -42,11 +47,11 @@ def test_sles_grow_root(host):
     if boot_part:
         # Some images have a separate boot partition that is >= 1G
         result = host.run(
-            'df -BG {part} | sed 1D'.format(part=boot_part)
+            'df -B{unit} {part} | sed 1D'.format(unit=unit, part=boot_part)
         ).stdout.strip()
 
         boot_size = shlex.split(result)[1]  # Filesystem 1G-blocks
-        boot_size = int(boot_size.replace('G', ''))
+        boot_size = float(boot_size.replace(unit, ''))
     else:
         boot_size = 0
 
@@ -56,15 +61,15 @@ def test_sles_grow_root(host):
     if var_part and var_part != root_part:
         # Some images have a separate /var partition that is >= 1G
         result = host.run(
-            'df -BG {part} | sed 1D'.format(part=var_part)
+            'df -B{unit} {part} | sed 1D'.format(unit=unit, part=var_part)
         ).stdout.strip()
 
         var_size = shlex.split(result)[1]  # Filesystem 1G-blocks
-        var_size = int(var_size.replace('G', ''))
+        var_size = float(var_size.replace(unit, ''))
     else:
         var_size = 0
 
     total_size = root_size + boot_size + var_size
 
     # Rounding can lead to small discrepancies
-    assert total_size in (disk_size - 1, disk_size, disk_size + 1)
+    assert (disk_size - 1) <= total_size <= (disk_size + 1)

--- a/usr/share/lib/img_proof/tests/SLES/test_sles_grow_root.py
+++ b/usr/share/lib/img_proof/tests/SLES/test_sles_grow_root.py
@@ -72,4 +72,4 @@ def test_sles_grow_root(host):
     total_size = root_size + boot_size + var_size
 
     # Rounding can lead to small discrepancies
-    assert (disk_size - 1) <= total_size <= (disk_size + 1)
+    assert (((disk_size - 1) <= total_size) and (total_size <= (disk_size + 1)))


### PR DESCRIPTION
Newer AWS metal instances have TB-sized drives, all available to the single instance. Some modification was needed to check for growing root on a drive that isn't measured in GB.

The TB measurements are usually a float, (ex 3.5TB) so integer casting doesn't work anymore.