### PR TITLE
Removes the base_product check from `is_suma` functions

### DIFF
--- a/usr/share/lib/img_proof/tests/conftest.py
+++ b/usr/share/lib/img_proof/tests/conftest.py
@@ -1,5 +1,6 @@
 import json
 import pytest
+import xml.etree.ElementTree as ET
 
 from susepubliccloudinfoclient import infoserverrequests
 
@@ -146,27 +147,47 @@ def is_sles_sap(host, get_baseproduct):
 
 
 @pytest.fixture()
-def is_suma_server(host):
+def is_suma_server(host, get_baseproduct, get_suma_version):
     def f():
         suma_server_product = '/etc/products.d/SUSE-Manager-Server.prod'
         suma_server = host.file(suma_server_product)
+        base_product = get_baseproduct()
+        suma_version = get_suma_version(suma_server_product)
 
+        if suma_version and suma_version.startswith('4'):
+            # For suma 4.3 baseproduct HAS to be SUMA proxy
+            return all([
+                suma_server.exists,
+                suma_server.is_file,
+                base_product == suma_server_product
+            ])
+        # For suma >=5 baseproduct is Micro and suma is an additional product
         return all([
-            suma_server.exists,
-            suma_server.is_file
+                suma_server.exists,
+                suma_server.is_file,
         ])
     return f
 
 
 @pytest.fixture()
-def is_suma_proxy(host):
+def is_suma_proxy(host, get_baseproduct, get_suma_version):
     def f():
         suma_proxy_product = '/etc/products.d/SUSE-Manager-Proxy.prod'
         suma_proxy = host.file(suma_proxy_product)
+        base_product = get_baseproduct()
+        suma_version = get_suma_version(suma_proxy_product)
 
+        if suma_version and suma_version.startswith('4'):
+            # For suma 4.3 baseproduct HAS to be SUMA proxy
+            return all([
+                suma_proxy.exists,
+                suma_proxy.is_file,
+                base_product == suma_proxy_product
+            ])
+        # For suma >=5 baseproduct is Micro and suma is an additional product
         return all([
-            suma_proxy.exists,
-            suma_proxy.is_file
+                suma_proxy.exists,
+                suma_proxy.is_file,
         ])
     return f
 
@@ -175,6 +196,20 @@ def is_suma_proxy(host):
 def is_suma(is_suma_server, is_suma_proxy):
     def f():
         return is_suma_server() or is_suma_proxy()
+    return f
+
+
+@pytest.fixture()
+def get_suma_version(host):
+    def f(product_file):
+        version = ''
+        try:
+            suma_product = host.file(product_file)
+            xmlroot = ET.fromstring(suma_product.content_string)
+            version = xmlroot.find('./version').text
+        except Exception:
+            pass
+        return version
     return f
 
 

--- a/usr/share/lib/img_proof/tests/conftest.py
+++ b/usr/share/lib/img_proof/tests/conftest.py
@@ -165,9 +165,9 @@ def is_suma_server(host, get_baseproduct, get_suma_version):
         # SUMA is included as an additional product
         sle_micro_product = '/etc/products.d/SLE-Micro.prod'
         return all([
-                suma_server.exists,
-                suma_server.is_file,
-                base_product == sle_micro_product
+            suma_server.exists,
+            suma_server.is_file,
+            base_product == sle_micro_product
         ])
     return f
 
@@ -191,9 +191,9 @@ def is_suma_proxy(host, get_baseproduct, get_suma_version):
         # SUMA is included as an additional product
         sle_micro_product = '/etc/products.d/SLE-Micro.prod'
         return all([
-                suma_proxy.exists,
-                suma_proxy.is_file,
-                base_product == sle_micro_product
+            suma_proxy.exists,
+            suma_proxy.is_file,
+            base_product == sle_micro_product
         ])
     return f
 

--- a/usr/share/lib/img_proof/tests/conftest.py
+++ b/usr/share/lib/img_proof/tests/conftest.py
@@ -161,10 +161,13 @@ def is_suma_server(host, get_baseproduct, get_suma_version):
                 suma_server.is_file,
                 base_product == suma_server_product
             ])
-        # For suma >=5 baseproduct is Micro and suma is an additional product
+        # For suma >=5 baseproduct has to be Micro
+        # SUMA is included as an additional product
+        sle_micro_product = '/etc/products.d/SLE-Micro.prod'
         return all([
                 suma_server.exists,
                 suma_server.is_file,
+                base_product == sle_micro_product
         ])
     return f
 
@@ -184,10 +187,13 @@ def is_suma_proxy(host, get_baseproduct, get_suma_version):
                 suma_proxy.is_file,
                 base_product == suma_proxy_product
             ])
-        # For suma >=5 baseproduct is Micro and suma is an additional product
+        # For suma >=5 baseproduct has to be Micro
+        # SUMA is included as an additional product
+        sle_micro_product = '/etc/products.d/SLE-Micro.prod'
         return all([
                 suma_proxy.exists,
                 suma_proxy.is_file,
+                base_product == sle_micro_product
         ])
     return f
 

--- a/usr/share/lib/img_proof/tests/conftest.py
+++ b/usr/share/lib/img_proof/tests/conftest.py
@@ -146,31 +146,27 @@ def is_sles_sap(host, get_baseproduct):
 
 
 @pytest.fixture()
-def is_suma_server(host, get_baseproduct):
+def is_suma_server(host):
     def f():
         suma_server_product = '/etc/products.d/SUSE-Manager-Server.prod'
         suma_server = host.file(suma_server_product)
-        base_product = get_baseproduct()
 
         return all([
             suma_server.exists,
-            suma_server.is_file,
-            base_product == suma_server_product
+            suma_server.is_file
         ])
     return f
 
 
 @pytest.fixture()
-def is_suma_proxy(host, get_baseproduct):
+def is_suma_proxy(host):
     def f():
         suma_proxy_product = '/etc/products.d/SUSE-Manager-Proxy.prod'
         suma_proxy = host.file(suma_proxy_product)
-        base_product = get_baseproduct()
 
         return all([
             suma_proxy.exists,
-            suma_proxy.is_file,
-            base_product == suma_proxy_product
+            suma_proxy.is_file
         ])
     return f
 

--- a/usr/share/lib/img_proof/tests/conftest.py
+++ b/usr/share/lib/img_proof/tests/conftest.py
@@ -155,7 +155,7 @@ def is_suma_server(host, get_baseproduct, get_suma_version):
         suma_version = get_suma_version(suma_server_product)
 
         if suma_version and suma_version.startswith('4'):
-            # For suma 4.3 baseproduct HAS to be SUMA proxy
+            # For suma 4.3 baseproduct HAS to be SUMA server
             return all([
                 suma_server.exists,
                 suma_server.is_file,

--- a/usr/share/lib/img_proof/tests/conftest.py
+++ b/usr/share/lib/img_proof/tests/conftest.py
@@ -156,18 +156,16 @@ def is_suma_server(host, get_baseproduct, get_suma_version):
 
         if suma_version and suma_version.startswith('4'):
             # For suma 4.3 baseproduct HAS to be SUMA server
-            return all([
-                suma_server.exists,
-                suma_server.is_file,
-                base_product == suma_server_product
-            ])
-        # For suma >=5 baseproduct has to be Micro
-        # SUMA is included as an additional product
-        sle_micro_product = '/etc/products.d/SLE-Micro.prod'
+            expected_product = suma_server_product
+        else:
+            # For suma >=5 baseproduct has to be Micro
+            # SUMA is included as an additional product
+            expected_product = '/etc/products.d/SLE-Micro.prod'
+
         return all([
             suma_server.exists,
             suma_server.is_file,
-            base_product == sle_micro_product
+            base_product == expected_product
         ])
     return f
 
@@ -182,18 +180,16 @@ def is_suma_proxy(host, get_baseproduct, get_suma_version):
 
         if suma_version and suma_version.startswith('4'):
             # For suma 4.3 baseproduct HAS to be SUMA proxy
-            return all([
-                suma_proxy.exists,
-                suma_proxy.is_file,
-                base_product == suma_proxy_product
-            ])
-        # For suma >=5 baseproduct has to be Micro
-        # SUMA is included as an additional product
-        sle_micro_product = '/etc/products.d/SLE-Micro.prod'
+            expected_product = suma_proxy_product
+        else:
+            # For suma >=5 baseproduct has to be Micro
+            # SUMA is included as an additional product
+            expected_product = '/etc/products.d/SLE-Micro.prod'
+
         return all([
             suma_proxy.exists,
             suma_proxy.is_file,
-            base_product == sle_micro_product
+            base_product == expected_product
         ])
     return f
 


### PR DESCRIPTION
 Suma 5 payg images are not identified properly by the `is_suma_server` function, as the function was checking the `baseproduct` to be the Suma server one.

For Suma 5 images the baseproduct is the one for Micro, but the `/etc/products.d` contains also the suma-server one.

```
lrwxrwxrwx. 1 root root   14 sep 17 08:14 baseproduct -> SLE-Micro.prod
-rw-r--r--. 1 root root 1558 feb 28  2024 SLE-Micro.prod
-rw-r--r--. 1 root root 1939 ago 19 09:24 SUSE-Manager-Server.prod
```

This PR removes the baseproduct check in those functions and just leaves the file check for Suma server.