### PR TITLE
Add check for registration comment in motd

### DIFF
--- a/usr/share/lib/img_proof/tests/SLES/test_sles_motd.py
+++ b/usr/share/lib/img_proof/tests/SLES/test_sles_motd.py
@@ -2,7 +2,7 @@ import pytest
 
 
 @pytest.mark.skipinbeta
-def test_sles_motd(host, get_release_value):
+def test_sles_motd(host, get_release_value, is_byos, is_suma_proxy):
     motd = host.file('/etc/motd')
 
     if not motd.exists:
@@ -30,3 +30,16 @@ def test_sles_motd(host, get_release_value):
             )
         )
     )
+
+    if is_byos() and not is_suma_proxy():
+        assert (
+            motd.contains('registercloudguest') or
+            motd.contains('SUSEConnect') or
+            motd.contains('transactional-update')
+        )
+    else:
+        assert (
+            not motd.contains('registercloudguest') and
+            not motd.contains('SUSEConnect') and
+            not motd.contains('transactional-update')
+        )


### PR DESCRIPTION
Registration comment should exist in byos motd but not in payg motd. SUMA Proxy byos is the exception as it's registered with SUMA server.