### PR TITLE
Remove unknown param in google-cloud-sdk for instance stop

### DIFF
--- a/img_proof/ipa_gce.py
+++ b/img_proof/ipa_gce.py
@@ -578,8 +578,7 @@ class GCECloud(IpaCloud):
         self.instances_client.stop(
             project=self.service_account_project,
             zone=self.region,
-            instance=self.running_instance_id,
-            discardLocalSsd=True
+            instance=self.running_instance_id
         )
 
         # In GCE an instance that is stopped has a state of TERMINATED:

--- a/img_proof/ipa_gce.py
+++ b/img_proof/ipa_gce.py
@@ -575,11 +575,13 @@ class GCECloud(IpaCloud):
 
     def _stop_instance(self):
         """Stop the instance."""
-        self.instances_client.stop(
+        request = compute_v1.StopInstanceRequest(
+            discard_local_ssd=True,
             project=self.service_account_project,
             zone=self.region,
             instance=self.running_instance_id
         )
+        self.instances_client.stop(request)
 
         # In GCE an instance that is stopped has a state of TERMINATED:
         # https://cloud.google.com/compute/docs/instances/instance-life-cycle


### PR DESCRIPTION
The parameter `discardLocalSsd` does no longer exist in the stop method of the instance client in google-cloud-sdk.

