### PR TITLE
Fix 16.0 detection on CSP CLI tests

### DIFF
--- a/usr/share/lib/img_proof/tests/SLES/Azure/test_sles_azure_csp_cli.py
+++ b/usr/share/lib/img_proof/tests/SLES/Azure/test_sles_azure_csp_cli.py
@@ -1,22 +1,8 @@
 import pytest
-import re
 
-def test_sles_azure_csp_cli(host, get_release_value, is_sle_micro):
-    version = get_release_value('VERSION')
-    assert version
-
-    if is_sle_micro():
-        pytest.skip('Micro has product version instead of SLE version.')
-
-    match = re.match(r'^(\d+)(?:[.-](?:SP)?(\d+))?$', version)
-    assert match, f"Unexpected version format: {version}"
-
-    major = match.group(1)
-    patchlevel = match.group(2)
-
-    if int(major) < 16:
+def test_sles_azure_csp_cli(host, is_sle_16_or_higher):
+    if not is_sle_16_or_higher():
         pytest.skip('Pre-SLE 16.0 versions do not have CSP CLI.')
-
 
     az_cmd = host.run('az --version')
     assert az_cmd.rc == 0, f"'az --version' failed with code {az_cmd.rc}"

--- a/usr/share/lib/img_proof/tests/SLES/EC2/test_sles_ec2_csp_cli.py
+++ b/usr/share/lib/img_proof/tests/SLES/EC2/test_sles_ec2_csp_cli.py
@@ -1,19 +1,7 @@
 import pytest
-import re
 
-def test_sles_ec2_csp_cli(host, get_release_value, is_sle_micro):
-    version = get_release_value('VERSION')
-    assert version
-
-    if is_sle_micro():
-        pytest.skip('Micro has product version instead of SLE version.')
-
-    match = re.match(r'^(\d+)(?:[.-](?:SP)?(\d+))?$', version)
-    assert match, f"Unexpected version format: {version}"
-
-    major = int(match.group(1))
-
-    if major < 16:
+def test_sles_ec2_csp_cli(host, is_sle_16_or_higher):
+    if not is_sle_16_or_higher():
         pytest.skip('Pre-SLE 16.0 versions do not have CSP CLI.')
 
     aws_cmd = host.run('aws --version')

--- a/usr/share/lib/img_proof/tests/SLES/GCE/test_sles_gce_csp_cli.py
+++ b/usr/share/lib/img_proof/tests/SLES/GCE/test_sles_gce_csp_cli.py
@@ -1,19 +1,7 @@
 import pytest
-import re
 
-def test_sles_gcp_csp_cli(host, get_release_value, is_sle_micro):
-    version = get_release_value('VERSION')
-    assert version
-
-    if is_sle_micro():
-        pytest.skip('Micro has product version instead of SLE version.')
-
-    match = re.match(r'^(\d+)(?:[.-](?:SP)?(\d+))?$', version)
-    assert match, f"Unexpected version format: {version}"
-
-    major = int(match.group(1))
-
-    if major < 16:
+def test_sles_gcp_csp_cli(host, is_sle_16_or_higher):
+    if not is_sle_16_or_higher():
         pytest.skip('Pre-SLE 16.0 versions do not have CSP CLI.')
 
     gcp_cmd = host.run('gcloud --version')

--- a/usr/share/lib/img_proof/tests/conftest.py
+++ b/usr/share/lib/img_proof/tests/conftest.py
@@ -1,9 +1,33 @@
 import json
 import pytest
+import re
 import xml.etree.ElementTree as ET
 
 from susepubliccloudinfoclient import infoserverrequests
 
+
+@pytest.fixture()
+def is_sle_16_or_higher(host, get_release_value):
+    """
+    Check if the SLE version is 16 or higher.
+    """
+    def f():
+        name = get_release_value('PRETTY_NAME')
+        version = get_release_value('VERSION')
+
+        if 'micro' in name.lower():
+            pytest.skip('Micro has product version instead of SLE version.')
+
+        match = re.match(r'^(\d\d).(\d)', version)
+
+        if not match:
+            return False
+
+        major = match.group(1)
+        patchlevel = match.group(2)
+
+        return int(major) >= 16
+    return f
 
 @pytest.fixture()
 def check_cloud_register(host):


### PR DESCRIPTION
Coming from https://openqa.suse.de/tests/18738129#step/SLES_Azure_test_sles_azure_csp_cli/1
Predecessor: https://github.com/SUSE-Enceladus/img-proof/pull/427