### PR TITLE
Handle SLES version parsing in beta stage

### DIFF
--- a/usr/share/lib/img_proof/tests/SLES/Azure/test_sles_azure_csp_cli.py
+++ b/usr/share/lib/img_proof/tests/SLES/Azure/test_sles_azure_csp_cli.py
@@ -1,26 +1,20 @@
 import pytest
-import re
 
-def test_sles_azure_csp_cli(host, get_release_value, is_sle_micro):
-    version = get_release_value('VERSION')
-    assert version
+
+def test_sles_azure_csp_cli(host, is_sle_micro, get_version):
+    version = get_version()
 
     if is_sle_micro():
         pytest.skip('Micro has product version instead of SLE version.')
 
-    match = re.match(r'^(\d+)(?:[.-](?:SP)?(\d+))?$', version)
-    assert match, f"Unexpected version format: {version}"
-
-    major = match.group(1)
-    patchlevel = match.group(2)
-
-    if int(major) < 16:
+    if version < 16.0:
         pytest.skip('Pre-SLE 16.0 versions do not have CSP CLI.')
-
 
     az_cmd = host.run('az --version')
     assert az_cmd.rc == 0, f"'az --version' failed with code {az_cmd.rc}"
-    assert 'azure-cli' in az_cmd.stdout, "Missing expected 'azure-cli' in version output"
+    assert 'azure-cli' in az_cmd.stdout, \
+        "Missing expected 'azure-cli' in version output"
     assert 'core' in az_cmd.stdout, "Missing expected 'core' in version output"
     assert 'msal' in az_cmd.stdout, "Missing expected 'msal' in version output"
-    assert 'azure-mgmt-resource' in az_cmd.stdout, "Missing expected 'azure-mgmt-resource' in version output"
+    assert 'azure-mgmt-resource' in az_cmd.stdout, \
+        "Missing expected 'azure-mgmt-resource' in version output"

--- a/usr/share/lib/img_proof/tests/SLES/EC2/test_sles_ec2_csp_cli.py
+++ b/usr/share/lib/img_proof/tests/SLES/EC2/test_sles_ec2_csp_cli.py
@@ -1,22 +1,18 @@
 import pytest
-import re
 
-def test_sles_ec2_csp_cli(host, get_release_value, is_sle_micro):
-    version = get_release_value('VERSION')
-    assert version
+
+def test_sles_ec2_csp_cli(host, is_sle_micro, get_version):
+    version = get_version()
 
     if is_sle_micro():
         pytest.skip('Micro has product version instead of SLE version.')
 
-    match = re.match(r'^(\d+)(?:[.-](?:SP)?(\d+))?$', version)
-    assert match, f"Unexpected version format: {version}"
-
-    major = int(match.group(1))
-
-    if major < 16:
+    if version < 16.0:
         pytest.skip('Pre-SLE 16.0 versions do not have CSP CLI.')
 
     aws_cmd = host.run('aws --version')
     assert aws_cmd.rc == 0, f"'aws --version' failed with code {aws_cmd.rc}"
-    assert 'aws-cli' in aws_cmd.stdout, "'aws-cli' not found in aws version output"
-    assert 'botocore' in aws_cmd.stdout, "'botocore' not found in aws version output"
+    assert 'aws-cli' in aws_cmd.stdout, \
+        "'aws-cli' not found in aws version output"
+    assert 'botocore' in aws_cmd.stdout, \
+        "'botocore' not found in aws version output"

--- a/usr/share/lib/img_proof/tests/SLES/GCE/test_sles_gce_csp_cli.py
+++ b/usr/share/lib/img_proof/tests/SLES/GCE/test_sles_gce_csp_cli.py
@@ -1,23 +1,20 @@
 import pytest
-import re
 
-def test_sles_gcp_csp_cli(host, get_release_value, is_sle_micro):
-    version = get_release_value('VERSION')
-    assert version
+
+def test_sles_gcp_csp_cli(host, is_sle_micro, get_version):
+    version = get_version()
 
     if is_sle_micro():
         pytest.skip('Micro has product version instead of SLE version.')
 
-    match = re.match(r'^(\d+)(?:[.-](?:SP)?(\d+))?$', version)
-    assert match, f"Unexpected version format: {version}"
-
-    major = int(match.group(1))
-
-    if major < 16:
+    if version < 16.0:
         pytest.skip('Pre-SLE 16.0 versions do not have CSP CLI.')
 
     gcp_cmd = host.run('gcloud --version')
     assert gcp_cmd.rc == 0, f"'gcloud help' failed with code {gcp_cmd.rc}"
-    assert 'Google Cloud SDK' in gcp_cmd.stdout, "'Google Cloud SDK' not found in gcloud version output"
-    assert 'core' in gcp_cmd.stdout, "'core' not found in gcloud version output"
-    assert 'minikube' in gcp_cmd.stdout, "'minikube' not found in gcloud version output"
+    assert 'Google Cloud SDK' in gcp_cmd.stdout, \
+        "'Google Cloud SDK' not found in gcloud version output"
+    assert 'core' in gcp_cmd.stdout, \
+        "'core' not found in gcloud version output"
+    assert 'minikube' in gcp_cmd.stdout, \
+        "'minikube' not found in gcloud version output"


### PR DESCRIPTION
- Add fixtures to check for skipinbeta flag and parse version
- Cleanup flake8 formatting errors
- Update SDK tests to use new fixtures