### PR TITLE
Drop version checks for csp cli tests

### DIFF
--- a/usr/share/lib/img_proof/tests/SLES/Azure/test_sles_azure_csp_cli.py
+++ b/usr/share/lib/img_proof/tests/SLES/Azure/test_sles_azure_csp_cli.py
@@ -1,23 +1,35 @@
 import pytest
 
 
-def test_sles_azure_csp_cli(host, is_sle_micro, get_version):
+def test_sles_azure_csp_cli(
+    host,
+    is_sle_micro,
+    is_suma,
+    is_chost,
+    get_version
+):
     version = get_version()
 
-    if is_sle_micro():
-        pytest.skip('Micro has product version instead of SLE version.')
-
-    if version < 16.0:
-        pytest.skip('Pre-SLE 16.0 versions do not have CSP CLI.')
+    if is_sle_micro() or is_suma() or is_chost():
+        pytest.skip('Skip image that does not contain the Azure CLI.')
 
     which_cmd = host.run('command -v az')
-    assert which_cmd.rc == 0, f"'{which_cmd.command}' failed with code {which_cmd.rc}."
+    assert which_cmd.rc == 0, \
+        f"'{which_cmd.command}' failed with code {which_cmd.rc}."
 
     az_cmd = host.run('az --version')
     assert az_cmd.rc == 0, f"'{az_cmd.command}' failed with code {az_cmd.rc}"
+
     assert 'azure-cli' in az_cmd.stdout, \
         "Missing expected 'azure-cli' in version output"
-    assert 'core' in az_cmd.stdout, "Missing expected 'core' in version output"
-    assert 'msal' in az_cmd.stdout, "Missing expected 'msal' in version output"
-    assert 'azure-mgmt-resource' in az_cmd.stdout, \
-        "Missing expected 'azure-mgmt-resource' in version output"
+    assert 'core' in az_cmd.stdout, \
+        "Missing expected 'core' in version output"
+
+    if version >= 15.0:
+        assert 'msal' in az_cmd.stdout, \
+            "Missing expected 'msal' in version output"
+        assert 'azure-mgmt-resource' in az_cmd.stdout, \
+            "Missing expected 'azure-mgmt-resource' in version output"
+    else:
+        assert 'telemetry' in az_cmd.stdout, \
+            "Missing expected 'telemetry' in version output"

--- a/usr/share/lib/img_proof/tests/SLES/EC2/test_sles_ec2_csp_cli.py
+++ b/usr/share/lib/img_proof/tests/SLES/EC2/test_sles_ec2_csp_cli.py
@@ -1,21 +1,29 @@
 import pytest
 
 
-def test_sles_ec2_csp_cli(host, is_sle_micro, get_version):
+def test_sles_ec2_csp_cli(host, is_sle_micro, is_suma, is_chost, get_version):
     version = get_version()
 
-    if is_sle_micro():
-        pytest.skip('Micro has product version instead of SLE version.')
-
-    if version < 16.0:
-        pytest.skip('Pre-SLE 16.0 versions do not have CSP CLI.')
+    if is_sle_micro() or is_suma() or is_chost():
+        pytest.skip('Skip image that does not contain the AWS CLI.')
 
     which_cmd = host.run('command -v aws')
-    assert which_cmd.rc == 0, f"'{which_cmd.command}' failed with code {which_cmd.rc}."
+    assert which_cmd.rc == 0, \
+        f"'{which_cmd.command}' failed with code {which_cmd.rc}."
 
     aws_cmd = host.run('aws --version')
-    assert aws_cmd.rc == 0, f"'{aws_cmd.command}' failed with code {aws_cmd.rc}"
-    assert 'aws-cli' in aws_cmd.stdout, \
-        "'aws-cli' not found in aws version output"
-    assert 'botocore' in aws_cmd.stdout, \
-        "'botocore' not found in aws version output"
+    assert aws_cmd.rc == 0, \
+        f"'{aws_cmd.command}' failed with code {aws_cmd.rc}"
+
+    if version >= 15.0:
+        assert 'aws-cli' in aws_cmd.stdout, \
+            "'aws-cli' not found in aws version output"
+        assert 'botocore' in aws_cmd.stdout, \
+            "'botocore' not found in aws version output"
+    else:
+        # The python version in 12-sp5 dumps the output
+        # to stderr even with exit code of 0
+        assert 'aws-cli' in aws_cmd.stderr, \
+            "'aws-cli' not found in aws version output"
+        assert 'botocore' in aws_cmd.stderr, \
+            "'botocore' not found in aws version output"

--- a/usr/share/lib/img_proof/tests/SLES/GCE/test_sles_gce.yaml
+++ b/usr/share/lib/img_proof/tests/SLES/GCE/test_sles_gce.yaml
@@ -1,3 +1,2 @@
 tests:
   - test_sles_gce_services
-  - test_sles_gce_csp_cli

--- a/usr/share/lib/img_proof/tests/SLES/GCE/test_sles_gce_csp_cli.py
+++ b/usr/share/lib/img_proof/tests/SLES/GCE/test_sles_gce_csp_cli.py
@@ -1,14 +1,9 @@
 import pytest
 
 
-def test_sles_gcp_csp_cli(host, is_sle_micro, get_version):
-    version = get_version()
-
+def test_sles_gcp_csp_cli(host, is_sle_micro):
     if is_sle_micro():
         pytest.skip('Micro has product version instead of SLE version.')
-
-    if version < 16.0:
-        pytest.skip('Pre-SLE 16.0 versions do not have CSP CLI.')
 
     which_cmd = host.run('command -v gcloud')
     assert which_cmd.rc == 0, f"'{which_cmd.command}' failed with code {which_cmd.rc}."

--- a/usr/share/lib/img_proof/tests/conftest.py
+++ b/usr/share/lib/img_proof/tests/conftest.py
@@ -233,6 +233,14 @@ def is_sle_micro(host, get_release_value):
 
 
 @pytest.fixture()
+def is_chost(host, get_variant):
+    def f():
+        variant = get_variant()
+        return 'chost' in variant.lower()
+    return f
+
+
+@pytest.fixture()
 def get_release_value(host):
     def f(key):
         release = host.file('/etc/os-release')


### PR DESCRIPTION
- Handle CLI check for all active and inactive images
- Skip check for suma, chost and micro images
- Drop GCE gcloud test from default test suite. gcloud is not in our images.