### PR TITLE
Include test to verify TDX is active in the instance

### DIFF
--- a/usr/share/lib/img_proof/tests/SLES/test_sles_tdx.py
+++ b/usr/share/lib/img_proof/tests/SLES/test_sles_tdx.py
@@ -1,0 +1,7 @@
+def test_sles_tdx(host):
+    expected = 'Intel TDX'
+
+    with host.sudo():
+        output = host.run('dmesg')
+
+    assert expected in output.stdout.strip()


### PR DESCRIPTION
The logs in dmesg for a VM with TDX active are:

```
$ sudo dmesg | grep -i tdx
[    0.000000] [    T0] tdx: Guest detected
[    1.448893] [    T0] process: using TDX aware idle routine
[    1.448893] [    T0] Memory Encryption Features active: Intel TDX
[    3.939523] [    T1] systemd[1]: Detected confidential virtualization tdx.
[    7.974125] [    T1] systemd[1]: Detected confidential virtualization tdx.
```