### PR TITLE
Add "zone" alias to command line

### DIFF
--- a/img_proof/scripts/cli.py
+++ b/img_proof/scripts/cli.py
@@ -221,6 +221,8 @@ def main(context, no_color):
 )
 @click.option(
     '--region',
+    '--zone',
+    'region',
     help='Cloud region to test image.'
 )
 @click.option(


### PR DESCRIPTION
--zone or --region now map to the same attribute.

Fixes #434 