### PR TITLE
Add new  test to wait 30 seconds for boot to complete + missing req

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ paramiko
 pytest
 PyYAML
 pytest-testinfra
-susepubliccloudinfo
 google-auth
 google-cloud-compute>=1.21.0
 aliyun-python-sdk-core


### PR DESCRIPTION
We've experienced some issues with some instance types as it takes some time to the boot process to finish after the test instance is accessible via SSH.

This PR includes a test that just waits for 30 seconds. This test can be used in these scenarios to give the instance 30 more seconds to execute some test.

