### PR TITLE
Fix bsc#1264510: Download correct OVAL file for SCAP test

### DIFF
--- a/usr/share/lib/img_proof/tests/SLES/test_sles_hardened.py
+++ b/usr/share/lib/img_proof/tests/SLES/test_sles_hardened.py
@@ -62,7 +62,7 @@ def test_sles_hardened(
     if not setup_swap(host):
         pytest.skip("Failed to setup swap, not enough memory.")
 
-    xml_path = "pub/projects/security/oval/suse.linux.enterprise.15.xml"
+    xml_path = "pub/projects/security/oval/suse.linux.enterprise.15-patch.xml"
     # Downloaded file should have slashes replaced by hyphens
     xml_file = xml_path.replace("/", "-")
     oscap_dir = "/tmp/oscap"
@@ -71,7 +71,7 @@ def test_sles_hardened(
 
     host.run("mkdir {}".format(oscap_dir))
     host.run(
-        "curl -o- https://ftp.suse.com/{path}.gz | gunzip -c > {dir}/{file}".format(
+        "curl -o- https://ftp.suse.com/{path}.bz2 | bunzip2 -c > {dir}/{file}.bz2".format(
             path=xml_path,
             file=xml_file,
             dir=oscap_dir,


### PR DESCRIPTION
The test_sles_hardened test was downloading the wrong OVAL definition file from the SUSE FTP server, causing oscap evaluation to fail with exit code 2.

The SCAP data stream (ssg-sle15-ds.xml) references:
  suse.linux.enterprise.15-patch.xml.bz2

But the test was downloading:
  suse.linux.enterprise.15.xml.gz

This caused oscap to fail when using --local-files because it couldn't find the expected patch.xml.bz2 file locally.

Updated to download the correct -patch.xml.bz2 variant and changed the decompression from gunzip to bunzip2 accordingly.