### PR TITLE
Fix paramiko stuck in `test_soft_reboot` test due to race condition

### DIFF
--- a/img_proof/ipa_cloud.py
+++ b/img_proof/ipa_cloud.py
@@ -823,6 +823,7 @@ class IpaCloud(object):
 
                     try:
                         self.distro.reboot(self._get_ssh_client())
+                        time.sleep(3)
                         client = self._get_ssh_client()
 
                         if self.host_key_fingerprint != \

--- a/img_proof/ipa_utils.py
+++ b/img_proof/ipa_utils.py
@@ -91,6 +91,8 @@ def establish_ssh_connection(ip,
                 allow_agent=False,
                 look_for_keys=False
             )
+            client.get_transport().set_keepalive(30)
+            return client
         except FileNotFoundError:
             raise
         except AuthenticationException:
@@ -110,6 +112,7 @@ def establish_ssh_connection(ip,
             attempts -= 1
             time.sleep(SECONDS_BETWEEN_REATTEMPTS)
         else:
+            client.get_transport().set_keepalive(30)
             return client
 
     raise IpaSSHException(
@@ -117,7 +120,7 @@ def establish_ssh_connection(ip,
     )
 
 
-def execute_ssh_command(client, cmd):
+def execute_ssh_command(client, cmd, timeout=None):
     """
     Execute given command using paramiko.
 
@@ -127,7 +130,7 @@ def execute_ssh_command(client, cmd):
         IpaSSHException: If stderr returns a non-empty string.
     """
     try:
-        stdin, stdout, stderr = client.exec_command(cmd)
+        stdin, stdout, stderr = client.exec_command(cmd, timeout=timeout)
         err = stderr.read()
         out = stdout.read()
         if err:
@@ -289,7 +292,7 @@ def get_ssh_client(ip,
     """Attempt to establish and test ssh connection."""
     if CLIENT_CACHE.get(ip):
         try:
-            execute_ssh_command(CLIENT_CACHE[ip], 'ls')
+            execute_ssh_command(CLIENT_CACHE[ip], 'ls', timeout=timeout)
         except Exception:
             clear_cache(ip)
         else:
@@ -308,7 +311,7 @@ def get_ssh_client(ip,
                 port,
                 timeout=wait_period
             )
-            execute_ssh_command(client, 'ls')
+            execute_ssh_command(client, 'ls', timeout=timeout)
         except FileNotFoundError:
             raise IpaSSHException(
                 'SSH private key file {key_file} not found.'.format(

--- a/tests/test_ipa_cloud.py
+++ b/tests/test_ipa_cloud.py
@@ -477,6 +477,7 @@ class TestIpaCloud(object):
         assert mock_hard_reboot.call_count == 1
         mock_hard_reboot.reset_mock()
 
+    @patch('time.sleep')
     @patch.object(IpaCloud, '_set_instance_ip')
     @patch.object(IpaCloud, '_set_image_id')
     @patch.object(IpaCloud, '_start_instance_if_stopped')
@@ -490,7 +491,8 @@ class TestIpaCloud(object):
         mock_get_ssh_client,
         mock_start_instance,
         mock_set_image_id,
-        mock_set_instance_ip
+        mock_set_instance_ip,
+        mock_sleep
     ):
         """Test exception when connection not established after hard reboot."""
         mock_soft_reboot.return_value = None

--- a/tests/test_ipa_utils.py
+++ b/tests/test_ipa_utils.py
@@ -33,7 +33,7 @@ from tempfile import NamedTemporaryFile
 from img_proof import ipa_utils
 from img_proof.ipa_exceptions import IpaSSHException, IpaUtilsException
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, mock_open
 
 LOCALHOST = '127.0.0.1'
 
@@ -451,3 +451,133 @@ def test_utils_generate_instance_name():
     name = ipa_utils.generate_instance_name('azure-img-proof-test')
     assert len(name) == 26
     assert name.startswith('azure-img-proof-test-')
+
+
+def test_get_public_ssh_key():
+    """Test get public SSH key."""
+    with patch('builtins.open', mock_open(read_data=b'ssh-rsa AAA...')) as m:
+        key = ipa_utils.get_public_ssh_key('key_file')
+        assert key == b'ssh-rsa AAA...'
+        m.assert_called_once_with('key_file.pub', 'rb')
+
+
+def test_get_public_ssh_key_exception():
+    """Test get public SSH key exception."""
+    with pytest.raises(IpaUtilsException) as error:
+        ipa_utils.get_public_ssh_key('nonexistent_key')
+    assert str(error.value) == (
+        'SSH public key file: nonexistent_key.pub cannot be found.'
+    )
+
+
+def test_find_test_file():
+    """Test find test file."""
+    tests = {'test_sles': '/path/to/test_sles.py'}
+
+    path = ipa_utils.find_test_file('test_sles', tests)
+    assert path == '/path/to/test_sles.py'
+
+    path = ipa_utils.find_test_file('test_sles::test_case', tests)
+    assert path == '/path/to/test_sles.py::test_case'
+
+    with pytest.raises(IpaUtilsException) as error:
+        ipa_utils.find_test_file('test_fake', tests)
+    assert str(error.value) == (
+        'Test file with name: test_fake cannot be found.'
+    )
+
+
+def test_parse_test_name():
+    """Test parse test name."""
+    assert ipa_utils.parse_test_name('test_name') == 'test_name'
+
+    name = '/path/to/test_file.py::TestClass::()::test_case'
+    assert ipa_utils.parse_test_name(name) == 'test_file::TestClass::test_case'
+
+    name = '/path/to/test_file.py::test_case'
+    assert ipa_utils.parse_test_name(name) == 'test_file::test_case'
+
+
+@patch('yaml.safe_load')
+def test_get_yaml_config(mock_yaml):
+    """Test get yaml config."""
+    mock_yaml.return_value = {'key': 'value'}
+
+    with patch('os.path.isfile') as mock_isfile:
+        mock_isfile.return_value = False
+        with pytest.raises(IpaUtilsException) as error:
+            ipa_utils.get_yaml_config('nonexistent.yaml')
+        assert str(error.value) == 'Config file not found: nonexistent.yaml'
+
+        mock_isfile.return_value = True
+        with patch('builtins.open', mock_open(read_data="key: value")):
+            result = ipa_utils.get_yaml_config('exists.yaml')
+            assert result == {'key': 'value'}
+
+
+def test_strtobool():
+    """Test strtobool function."""
+    assert ipa_utils.strtobool('y') == 1
+    assert ipa_utils.strtobool('yes') == 1
+    assert ipa_utils.strtobool('t') == 1
+    assert ipa_utils.strtobool('true') == 1
+    assert ipa_utils.strtobool('on') == 1
+    assert ipa_utils.strtobool('1') == 1
+
+    assert ipa_utils.strtobool('n') == 0
+    assert ipa_utils.strtobool('no') == 0
+    assert ipa_utils.strtobool('f') == 0
+    assert ipa_utils.strtobool('false') == 0
+    assert ipa_utils.strtobool('off') == 0
+    assert ipa_utils.strtobool('0') == 0
+
+    with pytest.raises(ValueError):
+        ipa_utils.strtobool('invalid')
+
+
+def test_load_json():
+    """Test load json function."""
+    with patch('builtins.open', mock_open(read_data='{"key": "value"}')):
+        result = ipa_utils.load_json('exists.json')
+        assert result == {'key': 'value'}
+
+
+def test_get_tests_from_description():
+    """Test get tests from description."""
+    descriptions = {
+        'desc1': '/path/to/desc1.yaml',
+        'desc2': '/path/to/desc2.yaml'
+    }
+
+    with patch('img_proof.ipa_utils.get_yaml_config') as mock_get_yaml:
+        mock_get_yaml.side_effect = [
+            {'tests': ['test_1', 'test_2'], 'include': ['desc2']},
+            {'tests': ['test_3']}
+        ]
+        tests = ipa_utils.get_tests_from_description('desc1', descriptions)
+        assert tests == ['test_1', 'test_2', 'test_3']
+
+    with pytest.raises(IpaUtilsException) as error:
+        ipa_utils.get_tests_from_description('missing', {})
+    assert str(error.value) == (
+        'Test description file with name: missing cannot be located.'
+    )
+
+
+@patch.object(paramiko.SSHClient, 'connect')
+def test_utils_get_ssh_client_file_not_found(mock_connect):
+    """Test get ssh client file not found exception."""
+    mock_connect.side_effect = FileNotFoundError('File not found')
+    with pytest.raises(IpaSSHException) as error:
+        ipa_utils.get_ssh_client('127.0.0.1', 'key', timeout=1)
+    assert 'SSH private key file key not found.' in str(error.value)
+
+
+def test_ignored():
+    """Test ignored context manager."""
+    with ipa_utils.ignored(ValueError):
+        raise ValueError("This should be ignored")
+
+    with pytest.raises(TypeError):
+        with ipa_utils.ignored(ValueError):
+            raise TypeError("This should not be ignored")

--- a/tests/test_ipa_utils.py
+++ b/tests/test_ipa_utils.py
@@ -60,9 +60,14 @@ def test_utils_clear_cache(mock_exec_cmd):
         ipa_utils.CLIENT_CACHE[LOCALHOST]
 
 
+@patch.object(paramiko.SSHClient, 'get_transport')
 @patch.object(paramiko.SSHClient, 'exec_command')
 @patch.object(paramiko.SSHClient, 'connect')
-def test_utils_get_ssh_connection(mock_connect, mock_exec_cmd):
+def test_utils_get_ssh_connection(
+    mock_connect,
+    mock_exec_cmd,
+    mock_get_transport
+):
     """Test successful ssh connection."""
     stdin = stdout = stderr = MagicMock()
     stderr.read.return_value = b''
@@ -98,6 +103,7 @@ def test_utils_ssh_connect_exception(mock_connect, mock_sleep, mock_time):
     assert mock_connect.call_count > 0
 
 
+@patch.object(paramiko.SSHClient, 'get_transport')
 @patch.object(time, 'time')
 @patch.object(time, 'sleep')
 @patch.object(paramiko.SSHClient, 'connect')
@@ -106,7 +112,8 @@ def test_utils_ssh_connect_authexception_once(
     mock_exec_cmd,
     mock_connect,
     mock_sleep,
-    mock_time
+    mock_time,
+    mock_get_transport
 ):
     """Test auth exception raised happening once connecting to ssh."""
     mock_connect.side_effect = [


### PR DESCRIPTION

This week experienced a run of a test of the type `test_soft_reboot` that got stuck forever in Paramiko (>24 hours).

Included the following measures to avoid the issue:

- In `img_proof/ipa_cloud.py` a race condition can happen because the distro.reboot  waits 1 second to  shut down SSHD in the remote instance and the test tries to get instantly the ssh_client again what could lead to a ssh connection to the sshd server before the reboot.
- Also included activating a keep_alive in the ssh transport, so keepalive messages are sent every 30s if the channel is silent. This would set timers in the channel so it does not get stuck forever.
- Additionally includes a timeout in the `execute_ssh_command` (defaulting to None). That param is included in the test `ls` command we send when getting the ssh connection (with the configured timeout value, defaulting to 600s), so an exception would be triggered in case that command gets stuck somehow.