### PR TITLE
Read product version from VERSION_ID

### DIFF
--- a/usr/share/lib/img_proof/tests/conftest.py
+++ b/usr/share/lib/img_proof/tests/conftest.py
@@ -390,31 +390,20 @@ def get_variant(host, get_release_value):
 
 
 @pytest.fixture()
-def get_version(host, get_release_value, is_beta_test):
+def get_version(host, get_release_value):
     """
     Parse version and return a float of major and patch version
+    VERSION_ID in sle is always in format MAJOR.MINOR version
     """
     def f():
-        version = get_release_value('VERSION')
-        assert version
+        version_id = get_release_value('VERSION_ID')
+        assert version_id
 
-        if is_beta_test():
-            beta_strings = r'(?: PublicRC)'
-        else:
-            beta_strings = r''
-
-        match = re.match(
-            r'^(?P<major_version>\d+)'
-            r'(?:[.-](?:[sS][pP])?'
-            r'(?P<minor_version>\d+)'
-            fr'{beta_strings}?)?$',
-            version
-        )
-
-        if not match:
+        try:
+            version = float(version_id)
+            return version
+        except:
             return None
-
-        return float(f'{match["major_version"]}.{match["minor_version"]}')
     return f
 
 


### PR DESCRIPTION
The VERSION_ID variable already provides required information that can be used in test objects.

We see a test failure, because the test code fails to extract the product version.
https://openqa.suse.de/tests/23213699/logfile?filename=img_proof_log-20260707005036.log.txt

```
>       if version >= 15.0:
E       TypeError: '>=' not supported between instances of 'NoneType' and 'float'
```
The VERSION variables might be tricky, as there is always a milestone build information appended that changes frequently.

VERSION="16.1 011-RC1" or
VERSION="16.1 010-OpenBeta"