### PR TITLE
Add SLE Micro 5.3/5.4/5.5 repos to repo test

### DIFF
--- a/usr/share/lib/img_proof/tests/SLES/conftest.py
+++ b/usr/share/lib/img_proof/tests/SLES/conftest.py
@@ -608,6 +608,15 @@ SLE_MICRO_5_4_BASE = [
     repo.replace('5.5', '5.4') for repo in SLE_MICRO_5_5_BASE
 ]
 
+SLE_MICRO_6_0_BASE = [
+    repo.replace('SLE-Micro', 'SL-Micro').replace('5.5', '6.0')
+    for repo in SLE_MICRO_5_5_BASE
+]
+
+SLE_MICRO_6_1_BASE = [
+    repo.replace('6.0', '6.1') for repo in SLE_MICRO_6_0_BASE
+]
+
 SLES_REPOS = {
     '12.5-X86_64': SLE_12_SP5_BASE + SLE_12_SP5_MODULES,
     '12.5-X86_64-SAP':
@@ -640,6 +649,10 @@ MICRO_REPOS = {
     '5.4-AARCH64': SLE_MICRO_5_4_BASE,
     '5.5-X86_64': SLE_MICRO_5_5_BASE,
     '5.5-AARCH64': SLE_MICRO_5_5_BASE,
+    '6.0-X86_64': SLE_MICRO_6_0_BASE,
+    '6.0-AARCH64': SLE_MICRO_6_0_BASE,
+    '6.1-X86_64': SLE_MICRO_6_1_BASE,
+    '6.1-AARCH64': SLE_MICRO_6_1_BASE,
 }
 
 

--- a/usr/share/lib/img_proof/tests/SLES/conftest.py
+++ b/usr/share/lib/img_proof/tests/SLES/conftest.py
@@ -594,6 +594,20 @@ BASE_16_1_SAP = [
     repo.replace('16.0', '16.1') for repo in BASE_16_0_SAP
 ]
 
+# SLE Micro is a single, non-modular product (unlike SLES), so it only
+# ever registers its own Pool/Updates/Debuginfo/Source repos.
+SLE_MICRO_5_5_BASE = [
+    'SLE-Micro-5.5-Debuginfo-Pool',
+    'SLE-Micro-5.5-Debuginfo-Updates',
+    'SLE-Micro-5.5-Pool',
+    'SLE-Micro-5.5-Source-Pool',
+    'SLE-Micro-5.5-Updates'
+]
+
+SLE_MICRO_5_4_BASE = [
+    repo.replace('5.5', '5.4') for repo in SLE_MICRO_5_5_BASE
+]
+
 SLES_REPOS = {
     '12.5-X86_64': SLE_12_SP5_BASE + SLE_12_SP5_MODULES,
     '12.5-X86_64-SAP':
@@ -617,6 +631,10 @@ SLES_REPOS = {
     '16.1-X86_64': BASE_16_1,
     '16.1-AARCH64': BASE_16_1,
     '16.1-X86_64-SAP': BASE_16_1_SAP,
+    '5.4-X86_64': SLE_MICRO_5_4_BASE,
+    '5.4-AARCH64': SLE_MICRO_5_4_BASE,
+    '5.5-X86_64': SLE_MICRO_5_5_BASE,
+    '5.5-AARCH64': SLE_MICRO_5_5_BASE,
 }
 
 

--- a/usr/share/lib/img_proof/tests/SLES/conftest.py
+++ b/usr/share/lib/img_proof/tests/SLES/conftest.py
@@ -631,6 +631,11 @@ SLES_REPOS = {
     '16.1-X86_64': BASE_16_1,
     '16.1-AARCH64': BASE_16_1,
     '16.1-X86_64-SAP': BASE_16_1_SAP,
+}
+
+# SLE Micro is a separate product from SLES, so it gets its own
+# lookup table instead of being folded into SLES_REPOS.
+MICRO_REPOS = {
     '5.4-X86_64': SLE_MICRO_5_4_BASE,
     '5.4-AARCH64': SLE_MICRO_5_4_BASE,
     '5.5-X86_64': SLE_MICRO_5_5_BASE,
@@ -642,6 +647,13 @@ SLES_REPOS = {
 def get_sles_repos():
     def f(version):
         return SLES_REPOS.get(version)
+    return f
+
+
+@pytest.fixture()
+def get_micro_repos():
+    def f(version):
+        return MICRO_REPOS.get(version)
     return f
 
 

--- a/usr/share/lib/img_proof/tests/SLES/test_sles_repos.py
+++ b/usr/share/lib/img_proof/tests/SLES/test_sles_repos.py
@@ -12,19 +12,22 @@ def test_sles_repos(
     is_sle_micro
 ):
     version = [str(get_version()), determine_architecture()]
+    is_micro = is_sle_micro()
 
-    if is_sle_micro():
-        repos = get_micro_repos('-'.join(version))
-    else:
+    if not is_micro:
         product = get_baseproduct()
         if 'sap' in product.lower():
             version.append('SAP')
         if 'hpc' in product.lower():
             version.append('HPC')
-        repos = get_sles_repos('-'.join(version))
 
     version = '-'.join(version)
     missing_repos = []
+
+    if is_micro:
+        repos = get_micro_repos(version)
+    else:
+        repos = get_sles_repos(version)
 
     if is_sles_sapcal():
         repos = [repo for repo in repos if 'Python2' not in repo]

--- a/usr/share/lib/img_proof/tests/SLES/test_sles_repos.py
+++ b/usr/share/lib/img_proof/tests/SLES/test_sles_repos.py
@@ -5,22 +5,26 @@ def test_sles_repos(
     get_instance_repos,
     get_version,
     get_sles_repos,
+    get_micro_repos,
     get_baseproduct,
     determine_architecture,
-    is_sles_sapcal
+    is_sles_sapcal,
+    is_sle_micro
 ):
     version = [str(get_version()), determine_architecture()]
 
-    product = get_baseproduct()
-    if 'sap' in product.lower():
-        version.append('SAP')
-    if 'hpc' in product.lower():
-        version.append('HPC')
+    if is_sle_micro():
+        repos = get_micro_repos('-'.join(version))
+    else:
+        product = get_baseproduct()
+        if 'sap' in product.lower():
+            version.append('SAP')
+        if 'hpc' in product.lower():
+            version.append('HPC')
+        repos = get_sles_repos('-'.join(version))
 
     version = '-'.join(version)
-
     missing_repos = []
-    repos = get_sles_repos(version)
 
     if is_sles_sapcal():
         repos = [repo for repo in repos if 'Python2' not in repo]


### PR DESCRIPTION
Adds SLE Micro 5.4/5.5 repo lists to test_sles_repos, which previously failed unconditionally for every SLE Micro on-demand image because the repo table only covered SLES's modular naming scheme.

* Related failure: [openqa.suse.de/t23628583](https://openqa.suse.de/tests/23628583)