### PR TITLE
Fix HPC12 module repos leaking into SLE 12 SAP/base repo table

### DIFF
--- a/usr/share/lib/img_proof/tests/SLES/conftest.py
+++ b/usr/share/lib/img_proof/tests/SLES/conftest.py
@@ -91,12 +91,7 @@ SLE_12_SP2_BASE = [
     'SLE-SDK12-SP2-Updates'
 ]
 
-SLE_12_SP2_MODULES = SLE_12_SP1_MODULES + [
-    'SLE-Module-HPC12-Debuginfo-Pool',
-    'SLE-Module-HPC12-Debuginfo-Updates',
-    'SLE-Module-HPC12-Pool',
-    'SLE-Module-HPC12-Updates'
-]
+SLE_12_SP2_MODULES = SLE_12_SP1_MODULES
 
 SLE_12_SP2_SAP = [
     'SLE12-SP2-SAP-Debuginfo-Pool',
@@ -109,6 +104,13 @@ SLE_12_SP2_SAP = [
     'SLE-HA12-SP2-Pool',
     'SLE-HA12-SP2-Source-Pool',
     'SLE-HA12-SP2-Updates'
+]
+
+SLE_12_SP2_HPC = [
+    'SLE-Module-HPC12-Debuginfo-Pool',
+    'SLE-Module-HPC12-Debuginfo-Updates',
+    'SLE-Module-HPC12-Pool',
+    'SLE-Module-HPC12-Updates'
 ]
 
 SLE_12_SP3_BASE = [
@@ -136,6 +138,8 @@ SLE_12_SP3_SAP = [
     'SLE-HA12-SP3-Source-Pool',
     'SLE-HA12-SP3-Updates'
 ]
+
+SLE_12_SP3_HPC = SLE_12_SP2_HPC
 
 SLE_12_SP4_BASE = [
     'SLES12-SP4-Debuginfo-Pool',
@@ -167,6 +171,8 @@ SLE_12_SP4_SAP = [
     'SLE-HA12-SP4-Updates'
 ]
 
+SLE_12_SP4_HPC = SLE_12_SP3_HPC
+
 SLE_12_SP5_BASE = [
     'SLES12-SP5-Debuginfo-Pool',
     'SLES12-SP5-Debuginfo-Updates',
@@ -196,6 +202,8 @@ SLE_12_SP5_SAP = [
     'SLE-HA12-SP5-Source-Pool',
     'SLE-HA12-SP5-Updates'
 ]
+
+SLE_12_SP5_HPC = SLE_12_SP4_HPC
 
 SLE_15_BASE = [
     'SLE-Module-Basesystem15-Debuginfo-Pool',
@@ -598,7 +606,8 @@ SLES_REPOS = {
     '12.5-X86_64': SLE_12_SP5_BASE + SLE_12_SP5_MODULES,
     '12.5-X86_64-SAP':
         SLE_12_SP5_SAP + SLE_12_SP5_BASE + SLE_12_SP5_MODULES,
-    '12.5-X86_64-HPC': SLE_12_SP5_BASE + SLE_12_SP5_MODULES,
+    '12.5-X86_64-HPC':
+        SLE_12_SP5_BASE + SLE_12_SP5_MODULES + SLE_12_SP5_HPC,
     '15.5-AARCH64': BASE_15_SP5,
     '15.5-X86_64': BASE_15_SP5 + SLE_15_SP5_X86_64_MODULES,
     '15.5-X86_64-SAP': BASE_15_SP5_SAP + SLE_15_SP5_X86_64_MODULES,


### PR DESCRIPTION
`test_sles_repos` fails on SLE 12-SP2..SP5 SAP/base images with
missing HPC12 repos, because `SLE_12_SP2_MODULES` bakes HPC12 repos
into the shared module list inherited by every SP2-SP5 plain/SAP
image. Split HPC12 into its own `SLE_12_SPX_HPC` lists (same pattern
as SLE 15.x), so plain/SAP entries drop HPC12 and `-HPC` becomes a
real, distinct combo instead of a copy of the plain entry. No repo
name strings changed, only which list they live in.

Fixes [progress.opensuse.org/issues/204648](https://progress.opensuse.org/issues/204648)