### PR TITLE
Use explicit .service suffix for cloud-init/agent service checks

### DIFF
--- a/usr/share/lib/img_proof/tests/SLES/Aliyun/test_sles_aliyun_services.py
+++ b/usr/share/lib/img_proof/tests/SLES/Aliyun/test_sles_aliyun_services.py
@@ -2,10 +2,10 @@ import pytest
 
 
 @pytest.mark.parametrize('name', [
-    ('cloud-init-local'),
-    ('cloud-init'),
-    ('cloud-config'),
-    ('cloud-final')
+    ('cloud-init-local.service'),
+    ('cloud-init.service'),
+    ('cloud-config.service'),
+    ('cloud-final.service')
 ])
 def test_sles_aliyun_one_shot_services(check_service, host, name):
     check_service(name, running=None)

--- a/usr/share/lib/img_proof/tests/SLES/Azure/test_sles_azure_services.py
+++ b/usr/share/lib/img_proof/tests/SLES/Azure/test_sles_azure_services.py
@@ -2,17 +2,17 @@ import pytest
 
 
 @pytest.mark.parametrize('name', [
-    ('waagent'),
+    ('waagent.service'),
 ])
 def test_sles_azure_running_services(check_service, name):
     check_service(name)
 
 
 @pytest.mark.parametrize('name', [
-    ('cloud-init-local'),
-    ('cloud-init'),
-    ('cloud-config'),
-    ('cloud-final')
+    ('cloud-init-local.service'),
+    ('cloud-init.service'),
+    ('cloud-config.service'),
+    ('cloud-final.service')
 ])
 def test_sles_azure_one_shot_services(check_service, host, name):
     check_service(name, running=None)

--- a/usr/share/lib/img_proof/tests/SLES/EC2/test_sles_ec2_services.py
+++ b/usr/share/lib/img_proof/tests/SLES/EC2/test_sles_ec2_services.py
@@ -2,10 +2,10 @@ import pytest
 
 
 @pytest.mark.parametrize('name', [
-    ('cloud-init-local'),
-    ('cloud-init'),
-    ('cloud-config'),
-    ('cloud-final')
+    ('cloud-init-local.service'),
+    ('cloud-init.service'),
+    ('cloud-config.service'),
+    ('cloud-final.service')
 ])
 def test_sles_ec2_services(check_service, host, name):
     check_service(name, running=None)

--- a/usr/share/lib/img_proof/tests/SLES/GCE/test_sles_gce_services.py
+++ b/usr/share/lib/img_proof/tests/SLES/GCE/test_sles_gce_services.py
@@ -2,8 +2,8 @@ import pytest
 
 
 @pytest.mark.parametrize('name', [
-    'google-guest-agent',
-    'google-osconfig-agent',
+    'google-guest-agent.service',
+    'google-osconfig-agent.service',
     'google-oslogin-cache.timer'
 ])
 def test_sles_gce_running_services(check_service, name):
@@ -11,8 +11,8 @@ def test_sles_gce_running_services(check_service, name):
 
 
 @pytest.mark.parametrize('name', [
-    'google-startup-scripts',
-    'google-shutdown-scripts',
+    'google-startup-scripts.service',
+    'google-shutdown-scripts.service',
 ])
 def test_sles_gce_one_shot_services(check_service, host, name):
     check_service(name, running=None)

--- a/usr/share/lib/img_proof/tests/SLES/oci/test_sles_oci_services.py
+++ b/usr/share/lib/img_proof/tests/SLES/oci/test_sles_oci_services.py
@@ -2,10 +2,10 @@ import pytest
 
 
 @pytest.mark.parametrize('name', [
-    ('cloud-init-local'),
-    ('cloud-init'),
-    ('cloud-config'),
-    ('cloud-final')
+    ('cloud-init-local.service'),
+    ('cloud-init.service'),
+    ('cloud-config.service'),
+    ('cloud-final.service')
 ])
 def test_sles_oci_services(check_service, host, name):
     check_service(name, running=None)


### PR DESCRIPTION
pytest-testinfra's SystemdService.is_enabled falls back to a SysV find(1) check for unit names without a recognized systemd suffix. On systems without /etc/rc?.d/ (e.g. SLE Micro), that fallback fails with a confusing AssertionError instead of a clear result when the unit does not exist — this is what's actually surfacing in the SLE Micro 5.4 failures described in bsc#1280068.

Adds an explicit `.service` suffix to the checked unit names in the EC2/Azure/GCE/OCI/Aliyun `test_sles_*_services.py` files, so a missing/failing unit raises testinfra's own clear `RuntimeError` instead of the misleading SysV-fallback `AssertionError`. This does not change pass/fail behavior for any currently-passing case, and does not skip or otherwise silence any check.

Whether SLE Micro 5.4 is genuinely expected to lack these services (vs. a real regression to be fixed image-side) is still an open question being tracked in bsc#1280068 / poo#206508 — a separate follow-up will address the SLE Micro version-skip once that's resolved either way.

* Related ticket: bsc#1280068
* Related failure: [openqa.suse.de/t24338047](https://openqa.suse.de/tests/24338047)
* Verification runs: